### PR TITLE
fix(tooltip): close popover when clicking outside

### DIFF
--- a/frontend/src/components/task/TaskContent.vue
+++ b/frontend/src/components/task/TaskContent.vue
@@ -183,7 +183,10 @@ export default {
       }
     },
     resetTimer: function() {
-      clearTimeout(this.timer)
+      if (this.timer != null) {
+        clearTimeout(this.timer)
+        this.timer = null
+      }
     },
     disablePopover: function() {
       localStorage.setItem('showPopoverHowToAssign', false)

--- a/frontend/src/components/task/TaskContent.vue
+++ b/frontend/src/components/task/TaskContent.vue
@@ -82,7 +82,7 @@ export default {
   mixins: [usersMixin],
   inject: ['isMobile'],
   props: { task: Object },
-  setup() {
+  setup: function() {
     const POPOVER_DELAY = 1200 // 1.2 seconds
     return { POPOVER_DELAY }
   },
@@ -127,7 +127,7 @@ export default {
     this.loadIdentityLinks(this.task.id)
     this.showPopoverWithDelay(this.task.assignee) // when first task is opened
   },
-  beforeUnmount() {
+  beforeUnmount: function() {
     this.resetTimer() // stop timeout for showPopoverWithDelay()
     this.stopListeningTouchEvents()
   },

--- a/frontend/src/components/task/TaskContent.vue
+++ b/frontend/src/components/task/TaskContent.vue
@@ -167,22 +167,22 @@ export default {
         }
       }, this.POPOVER_DELAY)
     },
-    startListeningTouchEvents() {
+    startListeningTouchEvents: function() {
       document.addEventListener("click", this.handleTouchEvent)
       document.addEventListener("focusin", this.handleTouchEvent)
     },
-    stopListeningTouchEvents() {
+    stopListeningTouchEvents: function() {
       document.removeEventListener("click", this.handleTouchEvent)
       document.removeEventListener("focusin", this.handleTouchEvent)
     },
-    handleTouchEvent(event) {
+    handleTouchEvent: function(event) {
       // Hide popover when clicking outside of it
       if (this.$refs.howToAssignPopover && !this.$refs.howToAssignPopover.$el.contains(event.target)) {
         this.displayPopover = false
         this.stopListeningTouchEvents()
       }
     },
-    resetTimer() {
+    resetTimer: function() {
       clearTimeout(this.timer)
     },
     disablePopover: function() {

--- a/frontend/src/components/task/TaskContent.vue
+++ b/frontend/src/components/task/TaskContent.vue
@@ -183,7 +183,7 @@ export default {
       }
     },
     resetTimer: function() {
-      if (this.timer != null) {
+      if (this.timer) {
         clearTimeout(this.timer)
         this.timer = null
       }


### PR DESCRIPTION
- listen to click events and close popover when clicking outside
- update displayPopover value when opened task is changed
- stop timeout when switching between tasks, assignee is changed, before unmount or when showPopoverWithDelay is executed again 
- use const for timeout's delay
- remove inconsistence when showing popover => always show it with delay

CIB7-246