### PR TITLE
chore(ui) enhance look for piecharts and dashboard view

### DIFF
--- a/frontend/src/components/processes/dashboard/DeploymentItem.vue
+++ b/frontend/src/components/processes/dashboard/DeploymentItem.vue
@@ -17,9 +17,9 @@
 
 -->
 <template>
-  <div class="col-3">
+  <div class="col-3 my-2">
     <router-link :to="link" :title="tooltip" class="text-decoration-none">
-      <div class="bg-light py-3 text-center">
+      <div class="bg-light py-3 text-center rounded">
         <h5 class="link-dark">{{ title }}</h5>
         <h2 class="link-dark">
           <span v-if="count !== null" :class="computedValueClass">{{ count }}</span>

--- a/frontend/src/components/processes/dashboard/PieChart.vue
+++ b/frontend/src/components/processes/dashboard/PieChart.vue
@@ -17,12 +17,12 @@
 
 -->
 <template>
-  <div>
+  <div class="my-2">
     <router-link v-if="title" :to="link" @click.stop :title="tooltip" class="text-decoration-none">
       <h5 class="link-dark text-center">{{ title }}</h5>
     </router-link>
     <div class="text-center waiting-box-container" v-if="loading">
-      <b-waiting-box class="d-inline" styling="width: 84%" :title="$t('admin.loading')" />
+      <b-waiting-box class="d-inline" styling="width: 150px" :title="$t('admin.loading')" />
     </div>
     <div v-else class="container apex-container">
       <apexchart type="donut" :options="chartOptions" :series="values" />
@@ -81,16 +81,33 @@ export default {
                 total: {
                   show: true,
                   label: '',
+                  fontFamily: '-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, sans-serif',
+                  fontWeight: 500,
+                  color: '#0C1A29',
+                  fontSize: '28.6px',
+                  offsetY: 16,
                   formatter: () => this.isEmptyChart ? '0' : this.values.reduce((a, b) => a + b, 0)
                 },
                 value: {
                   show: true,
+                  fontFamily: '-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, sans-serif',
                   fontWeight: 500,
-                  fontSize: '36px',
+                  color: '#0C1A29',
+                  fontSize: '28.6px',
+                  offsetY: 16,
                 },
               },
             },
           },
+        },
+        states: {
+          hover: {
+            filter: {
+              // Disable Hover Effect on Donut Chart
+              type: this.isEmptyChart ? 'none' : 'lighten', // or 'darken'
+              value: 0.15 // lighten by 15%
+            }
+          }
         },
         dataLabels: {
           enabled: false,
@@ -109,7 +126,7 @@ export default {
             },
           },
         },
-        colors: [
+        colors: this.isEmptyChart ? ['#C1CEDD'] : [
           '#59799B',
           '#84B6E5',
           '#C1CEDD',


### PR DESCRIPTION
Apply recent suggestions from Alice:

- Number in the circles must be placed a bit lower, and the same font and color as the "Deployed" numbers
- gray deployed boxes > with corner radius as the white Box
- margin under the gray boxes + 8px (should be the same as right and left)
- And for the spinner: is it possible to define the max size to 150px?
- In the Mobile view on dashboard: the space between the gray deployed boxes is missing. Should be 16px.
 