### PR TITLE
chore(i18n) update translations_de.json "Prozesse"

### DIFF
--- a/frontend/public/translations_de.json
+++ b/frontend/public/translations_de.json
@@ -857,7 +857,7 @@
 			"title": "Cockpit",
 			"tooltip": "Cockpit öffnen",
 			"processes": {
-				"title": "Prozesses",
+				"title": "Prozesse",
 				"tooltip": "Verfügbare Prozessdefinitionen durchsuchen"
 			},
 			"decisions": {


### PR DESCRIPTION
Plural von Prozesse ist nicht Prozesses