### PR TITLE
fix(i18n) unable switch languages de it

### DIFF
--- a/frontend/public/translations_de.json
+++ b/frontend/public/translations_de.json
@@ -54,7 +54,7 @@
 		"others": "Andere",
 		"unnamedProcess": "Unbenannter Prozess"
 	},
-	"process" : {
+	"process": {
 		"instanceRunning": "Instanz läuft",
 		"instanceIncidents": "Instanz mit Vorfällen",
 		"instanceFinished": "Instanz abgeschlossen",
@@ -178,7 +178,6 @@
 		"jobDefinitions": "Job-Definitionen",
 		"jobs": "Jobs",
 		"calledProcessDefinitions": "Aufgerufene Prozessdefinitionen"
-		}
 	},
 	"process-instance": {
 		"processInstanceId": "Prozessinstanz Id",

--- a/frontend/public/translations_it.json
+++ b/frontend/public/translations_it.json
@@ -166,7 +166,7 @@
 		},
 		"true": "Vero",
 		"false": "Falso",
-		"jobs": "Job"
+		"jobs": "Job",
 		"calledProcessDefinitions": "chiamato Definizioni di processo"
 	},
 	"process-instance": {

--- a/frontend/src/__tests__/i18n.test.js
+++ b/frontend/src/__tests__/i18n.test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('translations', () => {
+  const languages = ['de', 'en', 'it', 'ru', 'es']
+
+  languages.forEach(lang => {
+    it(`loadable_${lang}`, () => {
+      // eslint-disable-next-line no-undef
+      const filePath = resolve(__dirname, `../../public/translations_${lang}.json`)
+      const translations = JSON.parse(readFileSync(filePath, 'utf-8'))
+      expect(translations).toBeDefined()
+    })
+  })
+})
+ 


### PR DESCRIPTION
Fixes the issue where trying to switch to either the German or Italian (currently disabled) languages in the dropdown fails.