### PR TITLE
fix(settings): unable to send password recovery email

### DIFF
--- a/frontend/src/components/admin/ProfileUser.vue
+++ b/frontend/src/components/admin/ProfileUser.vue
@@ -264,7 +264,6 @@ import FlowTable from '@/components/common-components/FlowTable.vue'
 import SuccessAlert from '@/components/common-components/SuccessAlert.vue'
 import CIBForm from '@/components/common-components/CIBForm.vue'
 import { mapActions, mapGetters } from 'vuex'
-import FilterableSelectVue from '../task/filter/FilterableSelect.vue'
 
 export default {
   name: 'ProfileUser',
@@ -291,7 +290,7 @@ export default {
       focusedTenant: null,
       passwordPolicyError: false,
       passwordVisibility: { current: false, new: false, repeat: false },
-      sendingEmail: FilterableSelectVue,
+      sendingEmail: false,
       userTenants: []
     }
   },


### PR DESCRIPTION
This fixes an issue where it wasn't possible to send a password recovery email due to the loading state.