### PR TITLE
fix(i18n): task time-ago dates not updating locale with language switch

### DIFF
--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -38,6 +38,10 @@ import de from '@/assets/translations_de.json'
 import es from '@/assets/translations_es.json'
 import ru from '@/assets/translations_ru.json'
 
+import 'moment/dist/locale/de'
+import 'moment/dist/locale/es'
+import 'moment/dist/locale/ru'
+
 export const languages = {
   en: en,
   de: de,


### PR DESCRIPTION
Fixes the issue where the dates (i.e.: in the TaskList) were not updated with the current locale when switched (to any other than EN).