### PR TITLE
feat(provider): Add configurable engine REST path to SevenProviderBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,31 @@ cd cibseven-webclient
 mvn clean install
 ```
 
+### Configuration
+
+The webclient can be configured using Spring Boot properties. Key configuration options include:
+
+#### Engine REST API Configuration
+
+```yaml
+cibseven:
+  webclient:
+    engineRest:
+      url: http://localhost:8080          # Base URL of the CIB seven engine
+      path: /engine-rest                  # Configurable REST API path (default: /engine-rest)
+```
+
+The `path` property allows you to customize the engine REST API path to support different Jersey application configurations. For example, if your Spring Boot application defines a custom Jersey path:
+
+```yaml
+# Custom Jersey path example
+cibseven:
+  webclient:
+    engineRest:
+      url: http://localhost:8080
+      path: /different-path               # Custom path instead of default /engine-rest
+```
+
 ### Documentation
 
 - [CIB seven Manual](https://docs.cibseven.org/manual/latest/)

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/ActivityProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/ActivityProvider.java
@@ -35,50 +35,50 @@ public class ActivityProvider extends SevenProviderBase implements IActivityProv
 
 	@Override
 	public ActivityInstance findActivityInstance(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl+ "/engine-rest/process-instance/" + processInstanceId + "/activity-instances";
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/activity-instances";
 		return ((ResponseEntity<ActivityInstance>) doGet(url, ActivityInstance.class, user, false)).getBody();		
 	}
 
 	@Override
 	public List<ActivityInstanceHistory> findActivitiesInstancesHistory(Map<String, Object> queryParams, CIBUser user) {
-		String url = URLUtils.buildUrlWithParams(cibsevenUrl + "/engine-rest/history/activity-instance", queryParams);
+		String url = URLUtils.buildUrlWithParams(getEngineRestUrl() + "/history/activity-instance", queryParams);
 		return Arrays.asList(((ResponseEntity<ActivityInstanceHistory[]>) doGet(url, ActivityInstanceHistory[].class, user, false)).getBody());	
 	}
 
 	@Override
 	public List<ActivityInstanceHistory> findActivitiesInstancesHistory(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/activity-instance?processInstanceId=" + processInstanceId;
+		String url = getEngineRestUrl() + "/history/activity-instance?processInstanceId=" + processInstanceId;
 		return Arrays.asList(((ResponseEntity<ActivityInstanceHistory[]>) doGet(url, ActivityInstanceHistory[].class, user, false)).getBody());	
 	}
 	
 	@Override
 	public List<ActivityInstanceHistory> findActivityInstanceHistory(String processInstanceId, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/history/activity-instance?processInstanceId=" + processInstanceId;
+		String url = getEngineRestUrl() + "/history/activity-instance?processInstanceId=" + processInstanceId;
 		return Arrays.asList(doGet(url, ActivityInstanceHistory[].class, user, false).getBody());
 	}
 	
 	@Override
 	public ActivityInstance findActivityInstances(String processInstanceId, CIBUser user) throws SystemException {
-		String url = cibsevenUrl+ "/engine-rest/process-instance/" + processInstanceId + "/activity-instances";
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/activity-instances";
 		return doGet(url, ActivityInstance.class, user, false).getBody();
 	}
 	
 	@Override
 	public void deleteVariableByExecutionId(String executionId, String variableName, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/execution/" + executionId + "/localVariables/" + variableName;
+		String url = getEngineRestUrl() + "/execution/" + executionId + "/localVariables/" + variableName;
 		doDelete(url, user);
 	}
 
 	@Override
 	public void deleteVariableHistoryInstance(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/variable-instance/" + id;
+		String url = getEngineRestUrl() + "/history/variable-instance/" + id;
 		doDelete(url, user);
 	}
 
 	@Override
 	public Collection<ActivityInstanceHistory> findActivitiesProcessDefinitionHistory(String processDefinitionId,
 			CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/activity-instance?processDefinitionId=" + processDefinitionId;
+		String url = getEngineRestUrl() + "/history/activity-instance?processDefinitionId=" + processDefinitionId;
 		return Arrays.asList(((ResponseEntity<ActivityInstanceHistory[]>) doGet(url, ActivityInstanceHistory[].class, user, false)).getBody());
 	}
 	

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/BatchProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/BatchProvider.java
@@ -101,7 +101,7 @@ public class BatchProvider extends SevenProviderBase implements IBatchProvider {
 	
 	@Override
 	public Object setRemovalTime(Map<String, Object> payload) {
-        String url = "/history/batch/set-removal-time";
+        String url = getEngineRestUrl() + "/history/batch/set-removal-time";
         return ((ResponseEntity<Object>) doPost(url, payload, null, null)).getBody();
     }
     
@@ -113,12 +113,12 @@ public class BatchProvider extends SevenProviderBase implements IBatchProvider {
     
 	@Override
 	public Object getCleanableBatchReportCount() {
-        String url = "/history/batch/cleanable-batch-report/count";
+        String url = getEngineRestUrl() + "/history/batch/cleanable-batch-report/count";
         return ((ResponseEntity<Object>) doGet(url, Object.class, null, false)).getBody();
     }
 	
     private String buildUrlWithParams(String path, Map<String, Object> queryParams) {
-	    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(cibsevenUrl + "/engine-rest" + path);
+	    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(getEngineRestUrl() + path);
 	    queryParams.forEach((key, value) -> {
 	        if (value != null) {
 	            builder.queryParam(key, value);

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/DecisionProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/DecisionProvider.java
@@ -34,49 +34,49 @@ public class DecisionProvider extends SevenProviderBase implements IDecisionProv
 	
 	@Override
 	public Collection<Decision> getDecisionDefinitionList(Map<String, Object> queryParams, CIBUser user) {
-		String url = buildUrlWithParams(cibsevenUrl + "/engine-rest/decision-definition", queryParams);
+		String url = buildUrlWithParams(getEngineRestUrl() + "/decision-definition", queryParams);
 		return Arrays.asList(((ResponseEntity<Decision[]>) doGet(url, Decision[].class, user, false)).getBody());
 	}
 
 	@Override
 	public Object getDecisionDefinitionListCount(Map<String, Object> queryParams, CIBUser user) {
-		String url = buildUrlWithParams(cibsevenUrl + "/engine-rest/decision-definition/count", queryParams);    
+		String url = buildUrlWithParams(getEngineRestUrl() + "/decision-definition/count", queryParams);    
 		return ((ResponseEntity<Object>) doGet(url, Object.class, user, false)).getBody();
 	}
 	
 	@Override
 	public Decision getDecisionDefinitionByKey(String key, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key;
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key;
 		return ((ResponseEntity<Decision>) doGet(url, Decision.class, user, false)).getBody();
 	}
 
 	@Override
 	public Object getDiagramByKey(String key, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key + "/diagram";
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key + "/diagram";
 		return ((ResponseEntity<Object>) doGet(url, Object.class, user, false)).getBody();
 	}
 
 	@Override
 	public Object evaluateDecisionDefinitionByKey(Map<String, Object> data, String key, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key + "/evaluate";
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key + "/evaluate";
 		return ((ResponseEntity<Object>) doPost(url, data, null, user)).getBody();
 	}
 
 	@Override
 	public void updateHistoryTTLByKey(Map<String, Object> data, String key, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key + "/history-time-to-live";
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key + "/history-time-to-live";
 		doPut(url, data, user);
 	}
 
 	@Override
 	public Decision getDecisionDefinitionByKeyAndTenant(String key, String tenant, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key + "/tenant-id/" + tenant;
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key + "/tenant-id/" + tenant;
 		return ((ResponseEntity<Decision>) doGet(url, Decision.class, user, false)).getBody();
 	}
 
 	@Override
 	public Object getDiagramByKeyAndTenant(String key, String tenant, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key + "/tenant-id/" + tenant + "/diagram";
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key + "/tenant-id/" + tenant + "/diagram";
 		return ((ResponseEntity<Decision>) doGet(url, Decision.class, user, false)).getBody();
 	}
 
@@ -94,22 +94,22 @@ public class DecisionProvider extends SevenProviderBase implements IDecisionProv
 
 	@Override
 	public Object getXmlByKey(String key, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key + "/xml";
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key + "/xml";
 		return ((ResponseEntity<Decision>) doGet(url, Decision.class, user, false)).getBody();
 	}
 
 	@Override
 	public Object getXmlByKeyAndTenant(String key, String tenant, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/key/" + key + "/tenant-id/" + tenant + "/xml";
+		String url = getEngineRestUrl() + "/decision-definition/key/" + key + "/tenant-id/" + tenant + "/xml";
 		return ((ResponseEntity<Decision>) doGet(url, Decision.class, user, false)).getBody();
 	}
 
 	@Override
 	public Decision getDecisionDefinitionById(String id, Optional<Boolean> extraInfo, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/" + id;
+		String url = getEngineRestUrl() + "/decision-definition/" + id;
 		Decision decision = ((ResponseEntity<Decision>) doGet(url, Decision.class, user, false)).getBody();
 		if (extraInfo.isPresent() && extraInfo.get()) {
-			String urlCount = cibsevenUrl + "/engine-rest/history/decision-instance/count?decisionDefinitionId=" + decision.getId();
+			String urlCount = getEngineRestUrl() + "/history/decision-instance/count?decisionDefinitionId=" + decision.getId();
 			decision.setAllInstances(((ResponseEntity<JsonNode>) doGet(urlCount, JsonNode.class, user, false)).getBody().get("count").asLong());
 		}
 		return decision;
@@ -117,7 +117,7 @@ public class DecisionProvider extends SevenProviderBase implements IDecisionProv
 
 	@Override
 	public Object getDiagramById(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/" + id + "/diagram";
+		String url = getEngineRestUrl() + "/decision-definition/" + id + "/diagram";
 		return ((ResponseEntity<Decision>) doGet(url, Decision.class, user, false)).getBody();
 	}
 
@@ -129,24 +129,24 @@ public class DecisionProvider extends SevenProviderBase implements IDecisionProv
 
 	@Override
 	public void updateHistoryTTLById(String id, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/" + id + "/history-time-to-live";
+		String url = getEngineRestUrl() + "/decision-definition/" + id + "/history-time-to-live";
 		doPut(url, data, user);
 	}
 
 	@Override
 	public Object getXmlById(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition/" + id + "/xml";
+		String url = getEngineRestUrl() + "/decision-definition/" + id + "/xml";
 		return ((ResponseEntity<Object>) doGet(url, Object.class, user, false)).getBody();
 	}
 	
 	@Override
 	public Collection<Decision> getDecisionVersionsByKey(String key, Optional<Boolean> lazyLoad, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/decision-definition?key=" + key + "&sortBy=version&sortOrder=desc";
+		String url = getEngineRestUrl() + "/decision-definition?key=" + key + "&sortBy=version&sortOrder=desc";
 		Collection<Decision> decisions = Arrays.asList(((ResponseEntity<Decision[]>) doGet(url, Decision[].class, user, false)).getBody());		
 		
 		if (!lazyLoad.isPresent() || (lazyLoad.isPresent() && !lazyLoad.get())) {
 			for(Decision decision : decisions) {
-				String urlCount = cibsevenUrl + "/engine-rest/history/decision-instance/count?decisionDefinitionId=" + decision.getId();
+				String urlCount = getEngineRestUrl() + "/history/decision-instance/count?decisionDefinitionId=" + decision.getId();
 				decision.setAllInstances(((ResponseEntity<JsonNode>) doGet(urlCount, JsonNode.class, user, false)).getBody().get("count").asLong());
 			}
 		}
@@ -155,31 +155,31 @@ public class DecisionProvider extends SevenProviderBase implements IDecisionProv
 	
 	@Override
 	public Object getHistoricDecisionInstances(Map<String, Object> queryParams, CIBUser user){
-		String url = buildUrlWithParams(cibsevenUrl + "/engine-rest/history/decision-instance", queryParams);
+		String url = buildUrlWithParams(getEngineRestUrl() + "/history/decision-instance", queryParams);
 		return ((ResponseEntity<Object>) doGet(url, Object.class, user, false)).getBody();
 	}
 	
 	@Override
 	public Object getHistoricDecisionInstanceCount(Map<String, Object> queryParams, CIBUser user){
-		String url = buildUrlWithParams(cibsevenUrl + "/engine-rest/history/decision-instance/count", queryParams);
+		String url = buildUrlWithParams(getEngineRestUrl() + "/history/decision-instance/count", queryParams);
 		return ((ResponseEntity<Object>) doGet(url, Object.class, user, false)).getBody();
 	}
 	
 	@Override
 	public Object getHistoricDecisionInstanceById(String id, Map<String, Object> queryParams, CIBUser user){
-		String url = buildUrlWithParams(cibsevenUrl + "/engine-rest/history/decision-instance/" + id, queryParams);
+		String url = buildUrlWithParams(getEngineRestUrl() + "/history/decision-instance/" + id, queryParams);
 		return ((ResponseEntity<Object>) doGet(url, Object.class, user, false)).getBody();
 	}
 	
 	@Override
 	public Object deleteHistoricDecisionInstances(Map<String, Object> body, CIBUser user){
-		String url = cibsevenUrl + "/engine-rest/history/decision-instance/delete";
+		String url = getEngineRestUrl() + "/history/decision-instance/delete";
 		return ((ResponseEntity<Object>) doPost(url, body, null, user)).getBody();
 	}
 	
 	@Override
 	public Object setHistoricDecisionInstanceRemovalTime(Map<String, Object> body, CIBUser user){
-		String url = cibsevenUrl + "/engine-rest/history/decision-instance/set-removal-time";
+		String url = getEngineRestUrl() + "/history/decision-instance/set-removal-time";
 		return ((ResponseEntity<Object>) doPost(url, body, null, null)).getBody();
 	}
 	

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/DeploymentProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/DeploymentProvider.java
@@ -48,7 +48,7 @@ public class DeploymentProvider extends SevenProviderBase implements IDeployment
 
     @Override
 	public Deployment deployBpmn(MultiValueMap<String, Object> data, MultiValueMap<String, MultipartFile> file, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/deployment/create";
+		String url = getEngineRestUrl() + "/deployment/create";
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -76,19 +76,19 @@ public class DeploymentProvider extends SevenProviderBase implements IDeployment
 
     @Override
 	public Collection<Deployment> findDeployments(CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/deployment?sortBy=deploymentTime&sortOrder=desc";
+		String url = getEngineRestUrl() + "/deployment?sortBy=deploymentTime&sortOrder=desc";
 		return Arrays.asList(((ResponseEntity<Deployment[]>) doGet(url, Deployment[].class, user, false)).getBody());
 	}
 
 	@Override
 	public Collection<DeploymentResource> findDeploymentResources(String deploymentId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/deployment/" + deploymentId + "/resources";
+		String url = getEngineRestUrl() + "/deployment/" + deploymentId + "/resources";
 		return Arrays.asList(((ResponseEntity<DeploymentResource[]>) doGet(url, DeploymentResource[].class, user, false)).getBody());
 	}
    
 	@Override
 	public Data fetchDataFromDeploymentResource(HttpServletRequest rq, String deploymentId, String resourceId, String fileName) {
-		String url = cibsevenUrl + "/engine-rest/deployment/" + deploymentId + "/resources/" + resourceId + "/data";
+		String url = getEngineRestUrl() + "/deployment/" + deploymentId + "/resources/" + resourceId + "/data";
 		try {
 			RestTemplate restTemplate = new RestTemplate();
 		    restTemplate.getMessageConverters().add(new ByteArrayHttpMessageConverter());
@@ -111,7 +111,7 @@ public class DeploymentProvider extends SevenProviderBase implements IDeployment
 	
 	@Override
 	public void deleteDeployment(String deploymentId, Boolean cascade, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/deployment/" + deploymentId;
+		String url = getEngineRestUrl() + "/deployment/" + deploymentId;
 		if(cascade) url += "?cascade=true";
 		doDelete(url, user);
 	}

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/FilterProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/FilterProvider.java
@@ -35,13 +35,13 @@ public class FilterProvider extends SevenProviderBase implements IFilterProvider
 
 	@Override
 	public Collection<Filter> findFilters(CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/filter?resourceType=Task";
+		String url = getEngineRestUrl() + "/filter?resourceType=Task";
 		return Arrays.asList(((ResponseEntity<Filter[]>) doGet(url, Filter[].class, user, false)).getBody());
 	}
 
 	@Override
 	public Filter createFilter(Filter filter, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/filter/create";
+		String url = getEngineRestUrl() + "/filter/create";
 		try {
 			return ((ResponseEntity<Filter>) doPost(url, filter.json(), Filter.class, user)).getBody();
 		} catch (JsonProcessingException e) {
@@ -53,7 +53,7 @@ public class FilterProvider extends SevenProviderBase implements IFilterProvider
 	
 	@Override
 	public void updateFilter(Filter filter, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/filter/" + filter.getId();
+		String url = getEngineRestUrl() + "/filter/" + filter.getId();
 		try {
 			doPut(url, filter.json(), user);
 		} catch (JsonProcessingException e) {
@@ -65,7 +65,7 @@ public class FilterProvider extends SevenProviderBase implements IFilterProvider
 
 	@Override
 	public void deleteFilter(String filterId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/filter/" + filterId;
+		String url = getEngineRestUrl() + "/filter/" + filterId;
 		doDelete(url, user);
 	}
 

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/IncidentProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/IncidentProvider.java
@@ -38,7 +38,7 @@ public class IncidentProvider extends SevenProviderBase implements IIncidentProv
 			Optional<String> processInstanceId, Optional<String> executionId, Optional<String> activityId, Optional<String> causeIncidentId, Optional<String> rootCauseIncidentId, 
 			Optional<String> configuration, Optional<String> tenantIdIn, Optional<String> jobDefinitionIdIn, Optional<String> name, CIBUser user) {
 		
-		String url = cibsevenUrl + "/engine-rest/incident/count";
+		String url = getEngineRestUrl() + "/incident/count";
 		
 		String param = "";
 		param += addQueryParameter(param, "incidentId", incidentId, true);
@@ -67,7 +67,7 @@ public class IncidentProvider extends SevenProviderBase implements IIncidentProv
 			Optional<String> processInstanceId, Optional<String> executionId, Optional<String> activityId, Optional<String> causeIncidentId, Optional<String> rootCauseIncidentId, 
 			Optional<String> configuration, Optional<String> tenantIdIn, Optional<String> jobDefinitionIdIn, CIBUser user) {
 		
-		String url = cibsevenUrl + "/engine-rest/incident";
+		String url = getEngineRestUrl() + "/incident";
 		
 		String param = "";
 		param += addQueryParameter(param, "incidentId", incidentId, true);
@@ -91,7 +91,7 @@ public class IncidentProvider extends SevenProviderBase implements IIncidentProv
 	
 	@Override
 	public List<Incident> findIncidentByInstanceId(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/incident";
+		String url = getEngineRestUrl() + "/incident";
 		
 		String param = "";
 		param += addQueryParameter(param, "processInstanceId", Optional.of(processInstanceId), true);
@@ -103,19 +103,19 @@ public class IncidentProvider extends SevenProviderBase implements IIncidentProv
 
 	@Override
 	public Collection<Incident> fetchIncidents(String processDefinitionKey, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/incident?processDefinitionKeyIn=" + processDefinitionKey;
+		String url = getEngineRestUrl() + "/incident?processDefinitionKeyIn=" + processDefinitionKey;
 		return Arrays.asList(((ResponseEntity<Incident[]>) doGet(url, Incident[].class, user, false)).getBody());
 	}	
 
 	@Override
 	public void setIncidentAnnotation(String incidentId, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/incident/" + incidentId + "/annotation";
+		String url = getEngineRestUrl() + "/incident/" + incidentId + "/annotation";
 		doPut(url, data, user);
 	}	
 	
 	@Override
 	public Collection<Incident> fetchIncidentsByInstanceAndActivityId(String processDefinitionId, String activityId, CIBUser user) {
-	    String url = cibsevenUrl + "/engine-rest/incident?processDefinitionId=" + processDefinitionId + "&activityId=" + activityId;
+	    String url = getEngineRestUrl() + "/incident?processDefinitionId=" + processDefinitionId + "&activityId=" + activityId;
 	    return Arrays.asList(((ResponseEntity<Incident[]>) doGet(url, Incident[].class, user, false)).getBody());
 	}	
 	

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/JobDefinitionProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/JobDefinitionProvider.java
@@ -30,31 +30,31 @@ public class JobDefinitionProvider extends SevenProviderBase implements IJobDefi
 
 	@Override
 	public Collection<JobDefinition> findJobDefinitions(String params, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job-definition";
+		String url = getEngineRestUrl() + "/job-definition";
 		return Arrays.asList(((ResponseEntity<JobDefinition[]>) doPost(url, params, JobDefinition[].class, user)).getBody());
 	}
 	
 	@Override
 	public void suspendJobDefinition(String jobDefinitionId, String params, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job-definition/" + jobDefinitionId + "/suspended";
+		String url = getEngineRestUrl() + "/job-definition/" + jobDefinitionId + "/suspended";
 		doPut(url, params, user);
 	}
 	
 	@Override
 	public void overrideJobDefinitionPriority(String jobDefinitionId, String params, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job-definition/" + jobDefinitionId + "/jobPriority";
+		String url = getEngineRestUrl() + "/job-definition/" + jobDefinitionId + "/jobPriority";
 		doPut(url, params, user);
 	}
 	
 	@Override
 	public JobDefinition findJobDefinition(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job-definition/" + id;
+		String url = getEngineRestUrl() + "/job-definition/" + id;
 		return ((ResponseEntity<JobDefinition>) doGet(url, JobDefinition.class, user, false)).getBody();
 	}
 	
 	@Override
 	public void retryJobDefinitionById(String id, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job-definition/" + id + "/retries";
+		String url = getEngineRestUrl() + "/job-definition/" + id + "/retries";
 		doPut(url, data, user);
 	}	
 

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/JobProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/JobProvider.java
@@ -33,19 +33,19 @@ public class JobProvider extends SevenProviderBase implements IJobProvider {
 
 	@Override
 	public Collection<Job> getJobs(Map<String, Object> params, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job";
+		String url = getEngineRestUrl() + "/job";
 		return Arrays.asList(((ResponseEntity<Job[]>) doPost(url, params, Job[].class, user)).getBody());
 	}
 
 	@Override
 	public void setSuspended(String id, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job/" + id + "/suspended";
+		String url = getEngineRestUrl() + "/job/" + id + "/suspended";
 		doPut(url, data, user);
 	}
 
 	@Override
 	public void deleteJob(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job/" + id;
+		String url = getEngineRestUrl() + "/job/" + id;
 		doDelete(url, user);
 	}
 
@@ -65,7 +65,7 @@ public class JobProvider extends SevenProviderBase implements IJobProvider {
 	}
 	
 	private String buildUrlWithParams(String path, Map<String, Object> queryParams) {
-	    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(cibsevenUrl + "/engine-rest" + path);
+	    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(getEngineRestUrl() + path);
 	    queryParams.forEach((key, value) -> {
 	        if (value != null) {
 	            builder.queryParam(key, value);

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/ProcessProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/ProcessProvider.java
@@ -73,7 +73,7 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	
 	@Override
 	public Collection<Process> findProcesses(CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition?latestVersion=true&sortBy=name&sortOrder=desc";
+		String url = getEngineRestUrl() + "/process-definition?latestVersion=true&sortBy=name&sortOrder=desc";
 		Collection<Process> processes = Arrays.asList(((ResponseEntity<Process[]>) doGet(url, Process[].class, user, false)).getBody());
 		return processes;
 	}
@@ -86,12 +86,12 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 		/* The following code slow down the OFDKA system.*/
 		for (Process process : processes) {
 			if (fetchInstances) {
-				String urlInstances = cibsevenUrl + "/engine-rest/process-instance/count?processDefinitionKey=" + process.getKey();
+				String urlInstances = getEngineRestUrl() + "/process-instance/count?processDefinitionKey=" + process.getKey();
 				urlInstances += process.getTenantId() != null ? "&tenantIdIn=" + process.getTenantId() : "&withoutTenantId=true";
 				process.setRunningInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());	
 			}
 			if (fetchIncidents) {
-				String urlIncidents = cibsevenUrl + "/engine-rest/incident/count?processDefinitionKeyIn=" + process.getKey();
+				String urlIncidents = getEngineRestUrl() + "/incident/count?processDefinitionKeyIn=" + process.getKey();
 				urlIncidents += process.getTenantId() != null ? "&tenantIdIn=" + process.getTenantId() : "";
 				process.setIncidents(((ResponseEntity<JsonNode>) doGet(urlIncidents, JsonNode.class, user, false)).getBody().get("count").asLong());	
 			}
@@ -102,11 +102,11 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	@Override
 	public Collection<Process> findProcessesWithFilters(String filters, CIBUser user) {
 		try {
-			String url = cibsevenUrl + "/engine-rest/process-definition?" + URLDecoder.decode(filters, StandardCharsets.UTF_8.toString());
+			String url = getEngineRestUrl() + "/process-definition?" + URLDecoder.decode(filters, StandardCharsets.UTF_8.toString());
 			Collection<Process> processes = Arrays.asList(((ResponseEntity<Process[]>) doGet(url, Process[].class, user, false)).getBody());
 			
 			for(Process process : processes) {
-				String urlInstances = cibsevenUrl + "/engine-rest/process-instance/count?processDefinitionId=" + process.getId();
+				String urlInstances = getEngineRestUrl() + "/process-instance/count?processDefinitionId=" + process.getId();
 				process.setRunningInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());
 			}
 			
@@ -119,24 +119,24 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	
 	@Override
 	public Process findProcessByDefinitionKey(String key, String tenantId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition/key/" + key;
+		String url = getEngineRestUrl() + "/process-definition/key/" + key;
 		url += tenantId != null ? ("/tenant-id/" + tenantId) : "";
 		return ((ResponseEntity<Process>) doGet(url, Process.class, user, false)).getBody();		
 	}
 	
 	@Override
 	public Collection<Process> findProcessVersionsByDefinitionKey(String key, String tenantId, Optional<Boolean> lazyLoad, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition?key=" + key + "&sortBy=version&sortOrder=desc";
+		String url = getEngineRestUrl() + "/process-definition?key=" + key + "&sortBy=version&sortOrder=desc";
 		url += tenantId != null ? ("&tenantIdIn=" + tenantId) : "&withoutTenantId=true";
 		Collection<Process> processes = Arrays.asList(((ResponseEntity<Process[]>) doGet(url, Process[].class, user, false)).getBody());		
 		
 		if (!lazyLoad.isPresent() || (lazyLoad.isPresent() && !lazyLoad.get())) {
 			for(Process process : processes) {
-				String urlInstances = cibsevenUrl + "/engine-rest/history/process-instance/count?processDefinitionId=" + process.getId();
+				String urlInstances = getEngineRestUrl() + "/history/process-instance/count?processDefinitionId=" + process.getId();
 				process.setAllInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());
-				urlInstances = cibsevenUrl + "/engine-rest/history/process-instance/count?unfinished=true&processDefinitionId=" + process.getId();
+				urlInstances = getEngineRestUrl() + "/history/process-instance/count?unfinished=true&processDefinitionId=" + process.getId();
 				process.setRunningInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());
-				urlInstances = cibsevenUrl + "/engine-rest/history/process-instance/count?completed=true&processDefinitionId=" + process.getId();
+				urlInstances = getEngineRestUrl() + "/history/process-instance/count?completed=true&processDefinitionId=" + process.getId();
 				process.setCompletedInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());
 			}
 		}
@@ -145,15 +145,15 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	
 	@Override
 	public Process findProcessById(String id, Optional<Boolean> extraInfo, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + id;
+		String url = getEngineRestUrl() + "/process-definition/" + id;
 		Process process = ((ResponseEntity<Process>) doGet(url, Process.class, user, false)).getBody();
 		
 		if (extraInfo.isPresent() && extraInfo.get()) {
-			String urlInstances = cibsevenUrl + "/engine-rest/history/process-instance/count?processDefinitionId=" + id;
+			String urlInstances = getEngineRestUrl() + "/history/process-instance/count?processDefinitionId=" + id;
 			process.setAllInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());
-			urlInstances = cibsevenUrl + "/engine-rest/history/process-instance/count?unfinished=true&processDefinitionId=" + process.getId();
+			urlInstances = getEngineRestUrl() + "/history/process-instance/count?unfinished=true&processDefinitionId=" + process.getId();
 			process.setRunningInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());
-			urlInstances = cibsevenUrl + "/engine-rest/history/process-instance/count?completed=true&processDefinitionId=" + process.getId();
+			urlInstances = getEngineRestUrl() + "/history/process-instance/count?completed=true&processDefinitionId=" + process.getId();
 			process.setCompletedInstances(((ResponseEntity<JsonNode>) doGet(urlInstances, JsonNode.class, user, false)).getBody().get("count").asLong());
 		}
 		
@@ -162,25 +162,25 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	
 	@Override
 	public Collection<ProcessInstance> findProcessesInstances(String key, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-instance?processDefinitionKey=" + key;
+		String url = getEngineRestUrl() + "/process-instance?processDefinitionKey=" + key;
 		return Arrays.asList(((ResponseEntity<ProcessInstance[]>) doGet(url, ProcessInstance[].class, user, false)).getBody());	
 	}
 	
 	@Override
 	public Collection<ProcessInstance> findCurrentProcessesInstances(Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-instance";
+		String url = getEngineRestUrl() + "/process-instance";
 		return Arrays.asList(((ResponseEntity<ProcessInstance[]>) doPost(url, data, ProcessInstance[].class, user)).getBody());
 	}
 	
 	@Override
 	public ProcessDiagram fetchDiagram(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + id + "/xml";
+		String url = getEngineRestUrl() + "/process-definition/" + id + "/xml";
 		return ((ResponseEntity<ProcessDiagram>) doGet(url, ProcessDiagram.class, user, false)).getBody();
 	}
 	
 	@Override
 	public StartForm fetchStartForm(String processDefinitionId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + processDefinitionId + "/startForm";
+		String url = getEngineRestUrl() + "/process-definition/" + processDefinitionId + "/startForm";
 		return ((ResponseEntity<StartForm>) doGet(url, StartForm.class, user, false)).getBody();
 	}
 	
@@ -193,19 +193,19 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	
 	@Override
 	public void suspendProcessInstance(String processInstanceId, Boolean suspend, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId + "/suspended";
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/suspended";
 		doPut(url, "{ \"suspended\": " + suspend + " }", user);
 	}
 	
 	@Override
 	public void deleteProcessInstance(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId;
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId;
 		doDelete(url, user);
 	}
 	
 	@Override
 	public void suspendProcessDefinition(String processDefinitionId, Boolean suspend, Boolean includeProcessInstances, String executionDate, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + processDefinitionId + "/suspended";
+		String url = getEngineRestUrl() + "/process-definition/" + processDefinitionId + "/suspended";
 		doPut(url, "{ "
 				+ "\"suspended\": " + suspend + ","
 				+ "\"includeProcessInstances\": " + includeProcessInstances + ","
@@ -215,7 +215,7 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 
 	@Override
 	public ProcessStart startProcess(String processDefinitionKey, String tenantId, Map<String, Object> data, CIBUser user) throws SystemException, UnsupportedTypeException, ExpressionEvaluationException {
-		String url = cibsevenUrl + "/engine-rest/process-definition/key/" + processDefinitionKey;
+		String url = getEngineRestUrl() + "/process-definition/key/" + processDefinitionKey;
 		url += (tenantId != null ? ("/tenant-id/" + tenantId) : "") + "/start";
 		return ((ResponseEntity<ProcessStart>) doPost(url, data, ProcessStart.class, user)).getBody();
 	}
@@ -223,26 +223,26 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	@Override
 	public ProcessStart submitForm(String processDefinitionKey, String tenantId, Map<String, Object> data, CIBUser user) throws SystemException, UnsupportedTypeException, ExpressionEvaluationException {
 		// Used by Webdesk
-		String url = cibsevenUrl + "/engine-rest/process-definition/key/" + processDefinitionKey;
+		String url = getEngineRestUrl() + "/process-definition/key/" + processDefinitionKey;
 		url += (tenantId != null ? ("/tenant-id/" + tenantId) : "") + "/submit-form";
 		return ((ResponseEntity<ProcessStart>) doPost(url, data, ProcessStart.class, user)).getBody();
 	}
 	
 	@Override
 	public Collection<ProcessStatistics> findProcessStatistics(String processId, CIBUser user) throws SystemException, UnsupportedTypeException, ExpressionEvaluationException {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + processId + "/statistics?failedJobs=true";
+		String url = getEngineRestUrl() + "/process-definition/" + processId + "/statistics?failedJobs=true";
 		return Arrays.asList(((ResponseEntity<ProcessStatistics[]>) doGet(url, ProcessStatistics[].class, user, false)).getBody());
 	}
 
   @Override
   public Collection<ProcessStatistics> getProcessStatistics(CIBUser user) {
-    String url = cibsevenUrl + "/engine-rest/process-definition/statistics?failedJobs=true&rootIncidents=true";
+    String url = getEngineRestUrl() + "/process-definition/statistics?failedJobs=true&rootIncidents=true";
     return Arrays.asList(((ResponseEntity<ProcessStatistics[]>) doGet(url, ProcessStatistics[].class, user, false)).getBody());
   }
 	
 	@Override
 	public HistoryProcessInstance findHistoryProcessInstanceHistory(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/process-instance/" + processInstanceId;
+		String url = getEngineRestUrl() + "/history/process-instance/" + processInstanceId;
 		return ((ResponseEntity<HistoryProcessInstance>) doGet(url, HistoryProcessInstance.class, user, false)).getBody();
 	}
 	
@@ -252,14 +252,14 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 		Map<String, Object> queryParams = new HashMap<String, Object>();
 		if (firstResult.isPresent()) queryParams.put("firstResult", firstResult.get());
 		if (maxResults.isPresent()) queryParams.put("maxResults", maxResults.get());
-		String url = URLUtils.buildUrlWithParams(cibsevenUrl + "/engine-rest/history/process-instance", queryParams);
+		String url = URLUtils.buildUrlWithParams(getEngineRestUrl() + "/history/process-instance", queryParams);
 		return Arrays.asList(((ResponseEntity<HistoryProcessInstance[]>) doPost(url, data, HistoryProcessInstance[].class, user)).getBody());
 	}
 	
 	@Override
 	public Collection<HistoryProcessInstance> findProcessesInstancesHistory(String key, Optional<Boolean> active, 
 			Integer firstResult, Integer maxResults, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/process-instance?processDefinitionKey=" + key;
+		String url = getEngineRestUrl() + "/history/process-instance?processDefinitionKey=" + key;
 		if (active.isPresent()) {
 			url += (active.get()) ? "&unfinished=true" : "&finished=true";
 		}
@@ -270,7 +270,7 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	@Override
 	public Collection<HistoryProcessInstance> findProcessesInstancesHistoryById(String id, Optional<String> activityId, Optional<Boolean> active, 
 			Integer firstResult, Integer maxResults, String text, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/process-instance?processDefinitionId=" + id;
+		String url = getEngineRestUrl() + "/history/process-instance?processDefinitionId=" + id;
 		Map<String, Object> data = new HashMap<String, Object>();
 		List<TaskSorting> sorting = Arrays.asList(new TaskSorting("startTime", "desc"));
 		data.put("sorting", sorting);
@@ -336,27 +336,27 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	
 	@Override
 	public ProcessInstance findProcessInstance(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId;
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId;
 		return ((ResponseEntity<ProcessInstance>) doGet(url, ProcessInstance.class, user, false)).getBody();
 	}
 	
 	@Override
 	public Variable fetchProcessInstanceVariable(String processInstanceId, String variableName, String deserializeValue, CIBUser user) throws SystemException  {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId + "/variables/" + variableName;
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/variables/" + variableName;
 		url += StringUtils.isEmpty(deserializeValue) ? "" : "?deserializeValue=" + deserializeValue;
 		return ((ResponseEntity<Variable>) doGet(url, Variable.class, null, false)).getBody();
 	}
 	
 	@Override
 	public Collection<Process> findCalledProcessDefinitions(String processDefinitionId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + processDefinitionId + "/static-called-process-definitions";
+		String url = getEngineRestUrl() + "/process-definition/" + processDefinitionId + "/static-called-process-definitions";
 		
 		return Arrays.asList(((ResponseEntity<Process[]>) doGet(url, Process[].class, user, false)).getBody());
 	}
 	
 	@Override
 	public ResponseEntity<byte[]> getDeployedStartForm(String processDefinitionId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + processDefinitionId + "/deployed-start-form";
+		String url = getEngineRestUrl() + "/process-definition/" + processDefinitionId + "/deployed-start-form";
 		RestTemplate restTemplate = new RestTemplate();
 		restTemplate.getMessageConverters().add(new ByteArrayHttpMessageConverter());
 		HttpHeaders headers = new HttpHeaders();
@@ -371,7 +371,7 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 	@Override
 	public void updateHistoryTimeToLive(String id, Map<String, Object> data, CIBUser user) {
 		try {
-			String url = cibsevenUrl + "/engine-rest/process-definition/" + id + "/history-time-to-live";
+			String url = getEngineRestUrl() + "/process-definition/" + id + "/history-time-to-live";
 			doPut(url, data, user);
 		} catch (HttpStatusCodeException e) {
 			throw wrapException(e, user);
@@ -380,14 +380,14 @@ public class ProcessProvider extends SevenProviderBase implements IProcessProvid
 
 	@Override
 	public void deleteProcessInstanceFromHistory(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/process-instance/" + id;
+		String url = getEngineRestUrl() + "/history/process-instance/" + id;
 		doDelete(url, user);
 	}
 	
 	@Override
 	public void deleteProcessDefinition(String id, Optional<Boolean> cascade, CIBUser user) {
 		boolean cascadeVal = cascade.orElse(true);
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + id + "?cascade=" + cascadeVal;
+		String url = getEngineRestUrl() + "/process-definition/" + id + "?cascade=" + cascadeVal;
 		doDelete(url, user);
 	}
 

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/SevenProviderBase.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/SevenProviderBase.java
@@ -67,6 +67,17 @@ public abstract class SevenProviderBase {
 	
 	@Value("${cibseven.webclient.custom.spring.jackson.parser.max-size:20000000}") int jacksonParserMaxSize;
 	@Value("${cibseven.webclient.engineRest.url:./}") protected String cibsevenUrl;
+	@Value("${cibseven.webclient.engineRest.path:/engine-rest}") protected String engineRestPath;
+	
+	/**
+	 * Constructs the full engine REST base URL by combining the base URL with the configurable path
+	 * @return the complete engine REST URL
+	 */
+	protected String getEngineRestUrl() {
+		String baseUrl = cibsevenUrl.endsWith("/") ? cibsevenUrl.substring(0, cibsevenUrl.length() - 1) : cibsevenUrl;
+		String restPath = engineRestPath.startsWith("/") ? engineRestPath : "/" + engineRestPath;
+		return baseUrl + restPath;
+	}
 	
 	/**
 	 * Creates new Http headers and adds Authorization User token

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/SystemProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/SystemProvider.java
@@ -41,7 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SystemProvider extends SevenProviderBase implements ISystemProvider {
 
 	private int getSum(String metric, Map<String, Object> queryParams, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/metrics/" + metric + "/sum";
+		String url = getEngineRestUrl() + "/metrics/" + metric + "/sum";
 		String params = "";
 		for (Map.Entry<String, Object> entry : queryParams.entrySet()) {
 			Optional<String> value = Optional.ofNullable(entry.getValue()).map(Object::toString);
@@ -61,7 +61,7 @@ public class SystemProvider extends SevenProviderBase implements ISystemProvider
 
 	@Override
 	public JsonNode getTelemetryData(CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/telemetry/data";
+		String url = getEngineRestUrl() + "/telemetry/data";
 		return ((ResponseEntity<JsonNode>) doGet(url, JsonNode.class, user, false)).getBody();
 	}
 

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/TaskProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/TaskProvider.java
@@ -58,25 +58,25 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public Collection<Task> findTasks(String filter, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task?sortBy=created&sortOrder=desc" + (filter!=null ? filter : "");
+		String url = getEngineRestUrl() + "/task?sortBy=created&sortOrder=desc" + (filter!=null ? filter : "");
 		return Arrays.asList(((ResponseEntity<Task[]>) doGet(url, Task[].class, user, false)).getBody());
 	}
 
 	@Override
 	public Integer findTasksCount(Map<String, Object> filters, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/count";
+		String url = getEngineRestUrl() + "/task/count";
 		return ((ResponseEntity<JsonNode>) doPost(url, filters, JsonNode.class, user)).getBody().get("count").asInt();		
 	}
 	
 	@Override
 	public Collection<Task> findTasksByProcessInstance(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task?processInstanceId=" + processInstanceId;
+		String url = getEngineRestUrl() + "/task?processInstanceId=" + processInstanceId;
 		return Arrays.asList(((ResponseEntity<Task[]>) doGet(url, Task[].class, user, false)).getBody());		
 	}
 
 	@Override
 	public Collection<Task> findTasksByProcessInstanceAsignee(Optional<String> processInstanceId, Optional<String> createdAfter, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task";
+		String url = getEngineRestUrl() + "/task";
 		try {
 			url += "?assignee=" + URLEncoder.encode(user.getId(), StandardCharsets.UTF_8.toString());
 			url += processInstanceId.isPresent() ? "&processInstanceId=" + processInstanceId.get() : "";
@@ -91,13 +91,13 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public Task findTaskById(String id, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + id;
+		String url = getEngineRestUrl() + "/task/" + id;
 		return ((ResponseEntity<Task>) doGet(url, Task.class, user, false)).getBody();
 	}
 	
 	@Override
 	public void update(Task task, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + task.getId();
+		String url = getEngineRestUrl() + "/task/" + task.getId();
 		String filteredTask = "{ ";
 		if(task.getName() != null) filteredTask += "\"name\": \"" + task.getName() + "\" ";
 		if(task.getDescription() != null) filteredTask += ", \"description\": \"" + task.getDescription() + "\"";
@@ -116,7 +116,7 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public void setAssignee(String taskId, String assignee, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId;
+		String url = getEngineRestUrl() + "/task/" + taskId;
 		String variables = "{}";
 		
 		if(!assignee.equals("null")) {
@@ -131,7 +131,7 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public void submit(String taskId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/submit-form";
+		String url = getEngineRestUrl() + "/task/" + taskId + "/submit-form";
 		doPost(url, "{ \"variables\": {} }", String.class, user);
 	}
 	
@@ -145,7 +145,7 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public Object formReference(String taskId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/form-variables?variableNames=formReference";
+		String url = getEngineRestUrl() + "/task/" + taskId + "/form-variables?variableNames=formReference";
 		Variable formReference = ((ResponseEntity<ProcessVariables>) doGet(url, ProcessVariables.class, user, false)).getBody().getFormReference();
 		if (formReference == null) return new String("empty-task"); 
 		else return formReference.getValue();
@@ -153,7 +153,7 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public Collection<Task> findTasksByFilter(TaskFiltering filters, String filterId, CIBUser user, Integer firstResult, Integer maxResults) {
-		String url = cibsevenUrl + "/engine-rest/filter/" + filterId + "/list?firstResult=" + firstResult + "&maxResults=" + maxResults;		
+		String url = getEngineRestUrl() + "/filter/" + filterId + "/list?firstResult=" + firstResult + "&maxResults=" + maxResults;		
 		try {
 			return Arrays.asList(((ResponseEntity<Task[]>) doPost(url, filters.json(), Task[].class, user)).getBody());
 		} catch (JsonProcessingException e) {
@@ -165,7 +165,7 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public Integer findTasksCountByFilter(String filterId, CIBUser user, TaskFiltering filters) {
-		String url = cibsevenUrl + "/engine-rest/filter/" + filterId + "/count";		
+		String url = getEngineRestUrl() + "/filter/" + filterId + "/count";		
 		try {
 			return ((ResponseEntity<JsonNode>) doPost(url, filters.json(), JsonNode.class, user)).getBody().get("count").asInt();
 		} catch (JsonProcessingException e) {
@@ -177,26 +177,26 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public Collection<TaskHistory> findTasksByProcessInstanceHistory(String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/task?processInstanceId=" + processInstanceId + "&sortBy=startTime&sortOrder=desc";
+		String url = getEngineRestUrl() + "/history/task?processInstanceId=" + processInstanceId + "&sortBy=startTime&sortOrder=desc";
 		return Arrays.asList(((ResponseEntity<TaskHistory[]>) doGet(url, TaskHistory[].class, user, false)).getBody());
 	}
 	
 	@Override
 	public Collection<TaskHistory> findTasksByDefinitionKeyHistory(String taskDefinitionKey, String processInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/task?processInstanceId=" + processInstanceId + "&taskDefinitionKey=" + taskDefinitionKey;
+		String url = getEngineRestUrl() + "/history/task?processInstanceId=" + processInstanceId + "&taskDefinitionKey=" + taskDefinitionKey;
 		return Arrays.asList(((ResponseEntity<TaskHistory[]>) doGet(url, TaskHistory[].class, user, false)).getBody());				
 	}
 	
 	@Override
 	public Collection<Task> findTasksPost(Map<String, Object> data, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/task";
+		String url = getEngineRestUrl() + "/task";
 		return Arrays.asList(((ResponseEntity<Task[]>) doPost(url, data, Task[].class, user)).getBody());
 	}
 	
 	@Override
 	public Collection<IdentityLink> findIdentityLink(String taskId, Optional<String> type, CIBUser user) 
 	{
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId	+ "/identity-links";
+		String url = getEngineRestUrl() + "/task/" + taskId	+ "/identity-links";
 		
 		String param = "";
 		param += addQueryParameter(param, "type", type, true);
@@ -208,31 +208,31 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public void createIdentityLink(String taskId, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId	+ "/identity-links";
+		String url = getEngineRestUrl() + "/task/" + taskId	+ "/identity-links";
 		doPost(url, data, null, user);
 	}
 	
 	@Override
 	public void deleteIdentityLink(String taskId, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId	+ "/identity-links/delete";
+		String url = getEngineRestUrl() + "/task/" + taskId	+ "/identity-links/delete";
 		doPost(url, data, null, user);
 	}
 	
 	@Override
 	public void handleBpmnError(String taskId, Map<String, Object> data, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/bpmnError";
+		String url = getEngineRestUrl() + "/task/" + taskId + "/bpmnError";
 		doPost(url, data, null, user);
 	}
 
 	@Override
 	public Collection<TaskHistory> findTasksByTaskIdHistory(String taskId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/task?taskId=" + taskId;
+		String url = getEngineRestUrl() + "/history/task?taskId=" + taskId;
 		return Arrays.asList(((ResponseEntity<TaskHistory[]>) doGet(url, TaskHistory[].class, user, false)).getBody());
 	}
 	
 	@Override
 	public ResponseEntity<byte[]> getDeployedForm(String taskId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/deployed-form";
+		String url = getEngineRestUrl() + "/task/" + taskId + "/deployed-form";
 		RestTemplate restTemplate = new RestTemplate();
 		restTemplate.getMessageConverters().add(new ByteArrayHttpMessageConverter());
 		HttpHeaders headers = new HttpHeaders();
@@ -246,13 +246,13 @@ public class TaskProvider extends SevenProviderBase implements ITaskProvider {
 	
 	@Override
 	public Integer findHistoryTasksCount(Map<String, Object> filters, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/task/count";
+		String url = getEngineRestUrl() + "/history/task/count";
 		return ((ResponseEntity<JsonNode>) doPost(url, filters, JsonNode.class, user)).getBody().get("count").asInt();
 	}
 
 	@Override
 	public Collection<CandidateGroupTaskCount> getTaskCountByCandidateGroup(CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/task/report/candidate-group-count";
+		String url = getEngineRestUrl() + "/task/report/candidate-group-count";
 		return Arrays.asList(((ResponseEntity<CandidateGroupTaskCount[]>) doGet(url, CandidateGroupTaskCount[].class, user, false)).getBody());
 	}
 }

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/TenantProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/TenantProvider.java
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 public class TenantProvider extends SevenProviderBase implements ITenantProvider {
 	
 	private String buildUrlWithParams(String path, Map<String, Object> queryParams) {
-	    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(cibsevenUrl + "/engine-rest" + path);
+	    UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(getEngineRestUrl() + path);
 	    queryParams.forEach((key, value) -> {
 	        if (value != null) {
 	            builder.queryParam(key, value);
@@ -54,13 +54,13 @@ public class TenantProvider extends SevenProviderBase implements ITenantProvider
 
 	@Override
 	public Tenant fetchTenant(String tenantId, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/tenant/" + tenantId;
+		String url = getEngineRestUrl() + "/tenant/" + tenantId;
 		return ((ResponseEntity<Tenant>) doGet(url, Tenant.class, user, false)).getBody();
 	}
 
 	@Override
 	public void createTenant(Tenant newTenant, CIBUser user) throws InvalidUserIdException {
-		String url = cibsevenUrl + "/engine-rest/tenant/create";
+		String url = getEngineRestUrl() + "/tenant/create";
 		try {
 			doPost(url, newTenant.json(), null, user);
 		} catch (JsonProcessingException e) {
@@ -72,13 +72,13 @@ public class TenantProvider extends SevenProviderBase implements ITenantProvider
 	
 	@Override
 	public void deleteTenant(String tenantId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/tenant/" + tenantId;
+		String url = getEngineRestUrl() + "/tenant/" + tenantId;
 		doDelete(url, user);
 	}
 
 	@Override
 	public void udpateTenant(Tenant tenant, CIBUser user) {		
-		String url = cibsevenUrl + "/engine-rest/tenant/" + tenant.getId();
+		String url = getEngineRestUrl() + "/tenant/" + tenant.getId();
 		try {		
 			doPut(url, tenant.json() , user);
 		} catch (JsonProcessingException e) {
@@ -90,25 +90,25 @@ public class TenantProvider extends SevenProviderBase implements ITenantProvider
 	
 	@Override
 	public void addMemberToTenant(String tenantId, String userId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/tenant/" + tenantId + "/user-members/" + userId;
+		String url = getEngineRestUrl() + "/tenant/" + tenantId + "/user-members/" + userId;
 		doPut(url, "", user);
 	}	
 	
 	@Override
 	public void deleteMemberFromTenant(String tenantId, String userId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/tenant/" + tenantId + "/user-members/" + userId;
+		String url = getEngineRestUrl() + "/tenant/" + tenantId + "/user-members/" + userId;
 		doDelete(url, user);
 	}
 
 	@Override
 	public void addGroupToTenant(String tenantId, String groupId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/tenant/" + tenantId + "/group-members/" + groupId;
+		String url = getEngineRestUrl() + "/tenant/" + tenantId + "/group-members/" + groupId;
 		doPut(url, "", user);
 	}	
 	
 	@Override
 	public void deleteGroupFromTenant(String tenantId, String groupId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/tenant/" + tenantId + "/group-members/" + groupId;
+		String url = getEngineRestUrl() + "/tenant/" + tenantId + "/group-members/" + groupId;
 		doDelete(url, user);
 	}
 

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/UserProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/UserProvider.java
@@ -59,14 +59,14 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 	public Authorizations getUserAuthorization(String userId, CIBUser user) {
 		Authorizations auths = new Authorizations();
 		try {
-			String urlUsers = cibsevenUrl + "/engine-rest/authorization";
+			String urlUsers = getEngineRestUrl() + "/authorization";
 			UriComponentsBuilder builder;
 			
 			builder = UriComponentsBuilder.fromHttpUrl(urlUsers).queryParam("userIdIn", URLEncoder.encode(userId, StandardCharsets.UTF_8.toString()));
 	
 			Collection<Authorization> userAuthorizations = new ArrayList<Authorization>(Arrays.asList(((ResponseEntity<Authorization[]>) doGet(builder, Authorization[].class, user)).getBody()));
 			
-			String urlGroup = cibsevenUrl + "/engine-rest/group";
+			String urlGroup = getEngineRestUrl() + "/group";
 			builder = UriComponentsBuilder.fromHttpUrl(urlGroup).queryParam("member", URLEncoder.encode(userId, StandardCharsets.UTF_8.toString()));
 			Collection<UserGroup> userGroups = Arrays.asList(((ResponseEntity<UserGroup[]>) doGet(builder, UserGroup[].class, user)).getBody());
 			
@@ -77,7 +77,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 			}
 			
 			if (userGroups.size() > 0) {
-				String urlGroupAuthorizations = cibsevenUrl + "/engine-rest/authorization";
+				String urlGroupAuthorizations = getEngineRestUrl() + "/authorization";
 				builder = UriComponentsBuilder.fromHttpUrl(urlGroupAuthorizations).queryParam("groupIdIn", URLEncoder.encode(listGroups, StandardCharsets.UTF_8.toString()));
 				Collection<Authorization> groupsAuthorizations = Arrays.asList(((ResponseEntity<Authorization[]>) doGet(builder, Authorization[].class, user)).getBody());
 				userAuthorizations.addAll(groupsAuthorizations);
@@ -123,12 +123,12 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 	}
 	
 	public Collection<SevenUser> fetchUsers(CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/user";
+		String url = getEngineRestUrl() + "/user";
 		return Arrays.asList(((ResponseEntity<SevenUser[]>) doGet(url, SevenUser[].class, user, false)).getBody());	
 	}
 	
 	public SevenVerifyUser verifyUser(String username, String password, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/identity/verify";
+		String url = getEngineRestUrl() + "/identity/verify";
 		String body = "{\"username\": \"" + username + "\", \"password\": \"" + password + "\"}";
 		return ((ResponseEntity<SevenVerifyUser>) doPost(url, body, SevenVerifyUser.class, user)).getBody();	
 	}	
@@ -192,7 +192,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 			Optional<String> lastNameLike, Optional<String> email, Optional<String> emailLike, Optional<String> memberOfGroup, Optional<String> memberOfTenant,
 			Optional<String> idIn, Optional<String> firstResult, Optional<String> maxResults, Optional<String> sortBy, Optional<String> sortOrder) {
 		
-		String url = cibsevenUrl + "/engine-rest/user";
+		String url = getEngineRestUrl() + "/user";
 		
 		String param = "";
 		
@@ -249,7 +249,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 	
 	@Override
 	public void createUser(NewUser user, CIBUser flowUser) throws InvalidUserIdException {
-		String url = cibsevenUrl + "/engine-rest/user/create";
+		String url = getEngineRestUrl() + "/user/create";
 
 		try {
 			//	A JSON object with the following properties:
@@ -275,7 +275,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 	@Override
 	public void updateUserProfile(String userId, User user, CIBUser flowUser) 
 	{
-		String url = cibsevenUrl + "/engine-rest/user/" + userId + "/profile";
+		String url = getEngineRestUrl() + "/user/" + userId + "/profile";
 
 		try 
 		{
@@ -291,33 +291,33 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 
 	@Override
 	public void updateUserCredentials(String userId, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/user/" + userId + "/credentials";
+		String url = getEngineRestUrl() + "/user/" + userId + "/credentials";
 
 		doPut(url, data, user);
 	}
 	
 	@Override
 	public void addMemberToGroup(String groupId, String userId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/group/" + groupId + "/members/" + userId;
+		String url = getEngineRestUrl() + "/group/" + groupId + "/members/" + userId;
 		doPut(url, "", user);
 	}
 	
 	@Override
 	public void deleteMemberFromGroup(String groupId, String userId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/group/" + groupId + "/members/" + userId;
+		String url = getEngineRestUrl() + "/group/" + groupId + "/members/" + userId;
 		doDelete(url, user);
 	}
 
 	@Override
 	public void deleteUser(String userId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/user/" + userId;
+		String url = getEngineRestUrl() + "/user/" + userId;
 
 		doDelete(url, user);
 	}
 	
 	@Override
 	public SevenUser getUserProfile(String userId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/user/" + userId + "/profile";
+		String url = getEngineRestUrl() + "/user/" + userId + "/profile";
 
 		return doGet(url, SevenUser.class, user, false).getBody();
 	}
@@ -326,7 +326,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 	public Collection<UserGroup> findGroups(Optional<String> id, Optional<String> name, Optional<String> nameLike, Optional<String> type, 
 			Optional<String> member, Optional<String> memberOfTenant, Optional<String> sortBy, Optional<String> sortOrder, Optional<String> firstResult,
 			Optional<String> maxResults, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/group";
+		String url = getEngineRestUrl() + "/group";
 		
 		String param = "";
 		String wcard = getWildcard();
@@ -357,7 +357,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 
 	@Override
 	public void createGroup(UserGroup group, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/group/create";
+		String url = getEngineRestUrl() + "/group/create";
 
 		try {
 			doPost(url, group.json() , null, user);
@@ -371,7 +371,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 
 	@Override
 	public void updateGroup(String groupId, UserGroup group, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/group/" + groupId;
+		String url = getEngineRestUrl() + "/group/" + groupId;
 		try {
 			doPut(url, group.json(), user);
 		} 
@@ -384,7 +384,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 
 	@Override
 	public void deleteGroup(String groupId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/group/" + groupId;
+		String url = getEngineRestUrl() + "/group/" + groupId;
 		doDelete(url, user);
 	}
 
@@ -392,7 +392,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 	public Collection<Authorization> findAuthorization(Optional<String> id, Optional<String> type, Optional<String> userIdIn, Optional<String> groupIdIn, 
 			Optional<String> resourceType, Optional<String> resourceId, Optional<String> sortBy, Optional<String> sortOrder, Optional<String> firstResult,
 			Optional<String> maxResults, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/authorization";
+		String url = getEngineRestUrl() + "/authorization";
 		
 		String param = "";
 		param += addQueryParameter(param, "id", id, true);
@@ -413,7 +413,7 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 
 	@Override
 	public ResponseEntity<Authorization> createAuthorization(Authorization authorization, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/authorization/create";
+		String url = getEngineRestUrl() + "/authorization/create";
 
 		try {
 			return doPost(url, authorization.json(), Authorization.class, user);
@@ -427,13 +427,13 @@ public class UserProvider extends SevenProviderBase implements IUserProvider {
 
 	@Override
 	public void updateAuthorization(String authorizationId, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/authorization/" + authorizationId;
+		String url = getEngineRestUrl() + "/authorization/" + authorizationId;
 		doPut(url, data, user);
 	}
 
 	@Override
 	public void deleteAuthorization(String authorizationId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/authorization/" + authorizationId;
+		String url = getEngineRestUrl() + "/authorization/" + authorizationId;
 		doDelete(url, user);
 	}
 

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/UtilsProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/UtilsProvider.java
@@ -35,7 +35,7 @@ public class UtilsProvider extends SevenProviderBase implements IUtilsProvider {
 	@Override
 	public Collection<Message> correlateMessage(Map<String, Object> data, CIBUser user) throws SystemException {
 		//LHM overlay (webdesk)
-		String url = cibsevenUrl + "/engine-rest/message";
+		String url = getEngineRestUrl() + "/message";
 		ResponseEntity<Message[]> response = doPost(url, data, Message[].class, user);
 		if (response.hasBody()) {
 			return Arrays.asList(response.getBody());			
@@ -47,21 +47,21 @@ public class UtilsProvider extends SevenProviderBase implements IUtilsProvider {
 	
 	@Override
 	public String findStacktrace(String jobId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job/" + jobId	+ "/stacktrace";
+		String url = getEngineRestUrl() + "/job/" + jobId	+ "/stacktrace";
 		
 		return doGetWithHeader(url, String.class, user, false, MediaType.ALL).getBody();
 	}
 	
 	@Override
 	public void retryJobById(String jobId, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/job/" + jobId + "/retries";
+		String url = getEngineRestUrl() + "/job/" + jobId + "/retries";
 		doPut(url, data, user);
 	}
 	
 	@Override
 	public Collection<EventSubscription> getEventSubscriptions(Optional<String> processInstanceId,
 			Optional<String> eventType, Optional<String> eventName, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/event-subscription";
+		String url = getEngineRestUrl() + "/event-subscription";
 		String param = "";
 		param += addQueryParameter(param, "processInstanceId", processInstanceId, true);
 		param += addQueryParameter(param, "eventType", eventType, true);

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/VariableProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/providers/VariableProvider.java
@@ -67,13 +67,13 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	
 	@Override
 	public void modifyVariableByExecutionId(String executionId, Map<String, Object> data, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/execution/" + executionId + "/localVariables/";
+		String url = getEngineRestUrl() + "/execution/" + executionId + "/localVariables/";
 		doPost(url, data, null, user);
 	}
 	
 	@Override
 	public void modifyVariableDataByExecutionId(String executionId, String variableName, MultipartFile file, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/execution/" + executionId + "/localVariables/" + variableName + "/data";
+		String url = getEngineRestUrl() + "/execution/" + executionId + "/localVariables/" + variableName + "/data";
 		
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
@@ -94,14 +94,14 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	
 	@Override
 	public Collection<Variable> fetchProcessInstanceVariables(String processInstanceId, CIBUser user, Optional<Boolean> deserializeValue) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/variable-instance?processInstanceIdIn=" + processInstanceId;
+		String url = getEngineRestUrl() + "/variable-instance?processInstanceIdIn=" + processInstanceId;
 		url += deserializeValue.isPresent() ? "&deserializeValues=" + deserializeValue.get() : "";
 		return Arrays.asList(((ResponseEntity<VariableHistory[]>) doGet(url, VariableHistory[].class, user, false)).getBody());
 	}
 	
 	@Override
 	public ResponseEntity<byte[]> fetchVariableDataByExecutionId(String executionId, String variableName, CIBUser user) throws NoObjectFoundException, SystemException  {
-		String url = cibsevenUrl + "/engine-rest/execution/" + executionId + "/localVariables/" + variableName + "/data";
+		String url = getEngineRestUrl() + "/execution/" + executionId + "/localVariables/" + variableName + "/data";
 
 		try {
 			RestTemplate restTemplate = new RestTemplate();
@@ -121,26 +121,26 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	
 	@Override
 	public Collection<VariableHistory> fetchProcessInstanceVariablesHistory(String processInstanceId, CIBUser user, Optional<Boolean> deserializeValue) {
-		String url = cibsevenUrl + "/engine-rest/history/variable-instance?processInstanceId=" + processInstanceId;
+		String url = getEngineRestUrl() + "/history/variable-instance?processInstanceId=" + processInstanceId;
 		url += deserializeValue.isPresent() ? "&deserializeValues=" + deserializeValue.get() : "";
 		return Arrays.asList(((ResponseEntity<VariableHistory[]>) doGet(url, VariableHistory[].class, user, false)).getBody());
 	}	
 	
 	@Override
 	public Collection<VariableHistory> fetchActivityVariablesHistory(String activityInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/history/variable-instance?activityInstanceIdIn=" + activityInstanceId;
+		String url = getEngineRestUrl() + "/history/variable-instance?activityInstanceIdIn=" + activityInstanceId;
 		return Arrays.asList(((ResponseEntity<VariableHistory[]>) doGet(url, VariableHistory[].class, user, false)).getBody());
 	}
 	
 	@Override
 	public Collection<VariableHistory> fetchActivityVariables(String activityInstanceId, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/variable-instance?activityInstanceIdIn=" + activityInstanceId;
+		String url = getEngineRestUrl() + "/variable-instance?activityInstanceIdIn=" + activityInstanceId;
 		return Arrays.asList(((ResponseEntity<VariableHistory[]>) doGet(url, VariableHistory[].class, user, false)).getBody());
 	}	
 	
 	@Override
 	public ResponseEntity<byte[]> fetchHistoryVariableDataById(String id, CIBUser user) throws NoObjectFoundException, SystemException  {
-		String url = cibsevenUrl + "/engine-rest/history/variable-instance/" + id + "/data";
+		String url = getEngineRestUrl() + "/history/variable-instance/" + id + "/data";
 
 		try {
 			RestTemplate restTemplate = new RestTemplate();
@@ -161,27 +161,27 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	@Override
 	public Variable fetchVariable(String taskId, String variableName, 
 			Optional<Boolean> deserializeValue, CIBUser user) throws NoObjectFoundException, SystemException {		
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/variables/" + variableName;
+		String url = getEngineRestUrl() + "/task/" + taskId + "/variables/" + variableName;
 		url += deserializeValue.isPresent() ? "?deserializeValue=" + deserializeValue.get() : "";
 		return doGet(url, Variable.class, user, false).getBody();
 	}
 	
 	@Override
 	public void deleteVariable(String taskId, String variableName, CIBUser user) throws NoObjectFoundException, SystemException {		
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/variables/" + variableName;
+		String url = getEngineRestUrl() + "/task/" + taskId + "/variables/" + variableName;
 		doDelete(url, user);
 	}
 	
 	@Override
 	public Map<String, Variable> fetchFormVariables(String taskId, boolean deserializeValues, CIBUser user) throws NoObjectFoundException, SystemException {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/form-variables";
+		String url = getEngineRestUrl() + "/task/" + taskId + "/form-variables";
 		url += "?deserializeValues=" + deserializeValues;
 		return doGet(url, new ParameterizedTypeReference<Map<String, Variable>>() {}, user).getBody();
 	}	
 	
 	@Override
 	public Map<String, Variable> fetchFormVariables(List<String> variableListName, String taskId, CIBUser user) throws NoObjectFoundException, SystemException {
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/form-variables?variableNames=";
+		String url = getEngineRestUrl() + "/task/" + taskId + "/form-variables?variableNames=";
 
 		for(String variable: variableListName) {
 			url += variable + ",";
@@ -192,13 +192,13 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	
 	@Override
 	public Map<String, Variable> fetchProcessFormVariables(String key, CIBUser user) throws NoObjectFoundException, SystemException {
-		String url = cibsevenUrl + "/engine-rest/process-definition/key/" + key + "/form-variables";
+		String url = getEngineRestUrl() + "/process-definition/key/" + key + "/form-variables";
 		return doGet(url, new ParameterizedTypeReference<Map<String, Variable>>() {}, user).getBody();
 	}	
     
 	@Override
 	public NamedByteArrayDataSource fetchVariableFileData(String taskId, String variableName, CIBUser user) throws NoObjectFoundException, UnexpectedTypeException, SystemException {		
-		String url = cibsevenUrl + "/engine-rest/task/" + taskId + "/variables/" + variableName + "/data";
+		String url = getEngineRestUrl() + "/task/" + taskId + "/variables/" + variableName + "/data";
 		try {
 
 		    byte[] data = null;
@@ -248,7 +248,7 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	@Override
 	public ResponseEntity<byte[]> fetchProcessInstanceVariableData(String processInstanceId, String variableName,
 			CIBUser user) throws NoObjectFoundException, SystemException {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId + "/variables/" + variableName + "/data";
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/variables/" + variableName + "/data";
 
 		try {
 		    byte[] data = null;
@@ -292,7 +292,7 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	@Override
 	public ProcessStart submitStartFormVariables(String processDefinitionId, List<Variable> formResult, CIBUser user) throws SystemException {
 		//String url = camundaUrl + "/engine-rest/process-definition/key/" + processDefinitionKey + "/submit-form";
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + processDefinitionId + "/submit-form";
+		String url = getEngineRestUrl() + "/process-definition/" + processDefinitionId + "/submit-form";
 		ObjectMapper mapper = new ObjectMapper();
 		ObjectNode variables = mapper.getNodeFactory().objectNode();
 		ObjectNode modifications = mapper.getNodeFactory().objectNode();
@@ -351,14 +351,14 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	
 	@Override
 	public Variable fetchVariableByProcessInstanceId(String processInstanceId, String variableName, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId + "/variables/" + variableName + "?deserializeValue=true";
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/variables/" + variableName + "?deserializeValue=true";
 		return doGet(url, Variable.class, user, false).getBody();
 	}
 	
 	// TODO: Split it
 	@Override
 	public void saveVariableInProcessInstanceId(String processInstanceId, List<Variable> variables, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId + "/variables";
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/variables";
 
 		ObjectMapper mapper = new ObjectMapper();
 		ObjectNode variablesF = mapper.getNodeFactory().objectNode();
@@ -391,7 +391,7 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	// TODO: Split it
 	@Override
 	public void submitVariables(String processInstanceId, List<Variable> formResult, CIBUser user, String processDefinitionId) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/process-instance/" + processInstanceId + "/variables";
+		String url = getEngineRestUrl() + "/process-instance/" + processInstanceId + "/variables";
 
 		ObjectMapper mapper = new ObjectMapper();
 		ObjectNode variables = mapper.getNodeFactory().objectNode();
@@ -463,13 +463,13 @@ public class VariableProvider extends SevenProviderBase implements IVariableProv
 	
 	@Override
 	public Map<String, Variable> fetchProcessFormVariablesById(String id, CIBUser user) throws SystemException {
-		String url = cibsevenUrl + "/engine-rest/process-definition/" + id + "/form-variables";
+		String url = getEngineRestUrl() + "/process-definition/" + id + "/form-variables";
 		return doGet(url, new ParameterizedTypeReference<Map<String, Variable>>() {}, user).getBody();
 	}
 
 	@Override
 	public void putLocalExecutionVariable(String executionId, String varName, Map<String, Object> data, CIBUser user) {
-		String url = cibsevenUrl + "/engine-rest/execution/" + executionId + "/localVariables/" + varName;
+		String url = getEngineRestUrl() + "/execution/" + executionId + "/localVariables/" + varName;
 		doPut(url, data, user);
 	}
 	

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/InfoService.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/InfoService.java
@@ -55,6 +55,7 @@ public class InfoService extends BaseService {
 	@Value("${cibseven.webclient.link.accessibility:}") private String flowLinkAccessibility;
 	@Value("${cibseven.webclient.link.help:}") private String flowLinkHelp;
 	@Value("${cibseven.webclient.support-dialog:}") private String supportDialog;
+	@Value("${cibseven.webclient.engineRest.path:/engine-rest}") private String engineRestPath;
 	
 	
 	@Operation(
@@ -83,6 +84,7 @@ public class InfoService extends BaseService {
 		configJson.put("flowLinkHelp", flowLinkHelp);
 		configJson.put("productNamePageTitle", productNamePageTitle);
 		configJson.put("servicesBasePath", servicesBasePath);
+		configJson.put("engineRestPath", engineRestPath);
 		
         try {
             ObjectMapper mapper = new ObjectMapper();

--- a/cibseven-webclient-core/src/test/java/org/cibseven/webapp/providers/SevenProviderBaseTest.java
+++ b/cibseven-webclient-core/src/test/java/org/cibseven/webapp/providers/SevenProviderBaseTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.cibseven.webapp.providers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Test class for SevenProviderBase to verify configurable engine REST path functionality
+ */
+public class SevenProviderBaseTest {
+
+    /**
+     * Test provider implementation for testing purposes
+     */
+    private static class TestProvider extends SevenProviderBase {
+        // Empty implementation for testing
+    }
+
+    @Test
+    public void testGetEngineRestUrl_DefaultPath() {
+        TestProvider provider = new TestProvider();
+        ReflectionTestUtils.setField(provider, "cibsevenUrl", "http://localhost:8080");
+        ReflectionTestUtils.setField(provider, "engineRestPath", "/engine-rest");
+
+        String result = provider.getEngineRestUrl();
+        assertEquals("http://localhost:8080/engine-rest", result);
+    }
+
+    @Test
+    public void testGetEngineRestUrl_CustomPath() {
+        TestProvider provider = new TestProvider();
+        ReflectionTestUtils.setField(provider, "cibsevenUrl", "http://localhost:8080");
+        ReflectionTestUtils.setField(provider, "engineRestPath", "/different-path");
+
+        String result = provider.getEngineRestUrl();
+        assertEquals("http://localhost:8080/different-path", result);
+    }
+
+    @Test
+    public void testGetEngineRestUrl_BaseUrlWithTrailingSlash() {
+        TestProvider provider = new TestProvider();
+        ReflectionTestUtils.setField(provider, "cibsevenUrl", "http://localhost:8080/");
+        ReflectionTestUtils.setField(provider, "engineRestPath", "/engine-rest");
+
+        String result = provider.getEngineRestUrl();
+        assertEquals("http://localhost:8080/engine-rest", result);
+    }
+
+    @Test
+    public void testGetEngineRestUrl_PathWithoutLeadingSlash() {
+        TestProvider provider = new TestProvider();
+        ReflectionTestUtils.setField(provider, "cibsevenUrl", "http://localhost:8080");
+        ReflectionTestUtils.setField(provider, "engineRestPath", "engine-rest");
+
+        String result = provider.getEngineRestUrl();
+        assertEquals("http://localhost:8080/engine-rest", result);
+    }
+
+    @Test
+    public void testGetEngineRestUrl_BothWithSlashes() {
+        TestProvider provider = new TestProvider();
+        ReflectionTestUtils.setField(provider, "cibsevenUrl", "http://localhost:8080/");
+        ReflectionTestUtils.setField(provider, "engineRestPath", "/engine-rest");
+
+        String result = provider.getEngineRestUrl();
+        assertEquals("http://localhost:8080/engine-rest", result);
+    }
+
+    @Test
+    public void testGetEngineRestUrl_RelativeBaseUrl() {
+        TestProvider provider = new TestProvider();
+        ReflectionTestUtils.setField(provider, "cibsevenUrl", "./");
+        ReflectionTestUtils.setField(provider, "engineRestPath", "/engine-rest");
+
+        String result = provider.getEngineRestUrl();
+        assertEquals("./engine-rest", result);
+    }
+}

--- a/cibseven-webclient-web/src/main/resources/application.yaml
+++ b/cibseven-webclient-web/src/main/resources/application.yaml
@@ -18,6 +18,10 @@ cibseven:
     # Engine rest
     engineRest:
       url: http://localhost:8080
+      # Configurable path for the engine REST API (default: /engine-rest)
+      # This allows customization for different Jersey application paths
+      # Example: path: /different-path
+      path: /engine-rest
     historyLevel: full
     # Token generation
     authentication:


### PR DESCRIPTION
- Introduced a new property `engineRestPath` to allow customization of the engine REST API path.
- Implemented a method `getEngineRestUrl()` in `SevenProviderBase` to construct the full engine REST URL using the base URL and the configurable path.
- Updated all provider classes to utilize the new `getEngineRestUrl()` method for constructing URLs, ensuring consistency and flexibility.
- Added tests for `getEngineRestUrl()` to verify default and custom path functionality, including edge cases with slashes.
- Updated application configuration to support the new `engineRest.path` property in `application.yaml`.

Co-authored-by: GitHub Copilot in VSCode agent mode with Claude Sonnet 4