### PR TITLE
fix(deployments) validate sort order on load

### DIFF
--- a/frontend/src/__tests__/deployments.utils.test.js
+++ b/frontend/src/__tests__/deployments.utils.test.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { describe, it, expect } from 'vitest'
+import { sortDeployments } from '@/components/deployment/utils'
+
+const deployments = [
+  {
+    id: "b21d793d-29c4-11f0-8d84-00059a3c7a00",
+    name: "InvoiceProcessApplication",
+    deploymentTime: "2025-05-05T17:22:02.694+0200"
+  },
+  {
+    id: "b1d26673-29c4-11f0-8d84-00059a3c7a00",
+    name: null,
+    deploymentTime: "2025-05-05T17:22:02.217+0200"
+  }
+]
+
+describe('sortDeployments', () => {
+
+  describe('name', () => {
+    it('should sort by name ascending', () => {
+      const arr = [...deployments].sort((a, b) => sortDeployments(a, b, 'name', 'asc'))
+      expect(arr[0].name).toBeNull()
+      expect(arr[1].name).toBe('InvoiceProcessApplication')
+    })
+
+    it('should sort by name descending', () => {
+      const arr = [...deployments].sort((a, b) => sortDeployments(a, b, 'name', 'desc'))
+      expect(arr[0].name).toBe('InvoiceProcessApplication')
+      expect(arr[1].name).toBeNull()
+    })
+
+    it('sort 4 items, asc', () => {
+      const arr = [
+        {name: 'a2'},
+        {name: 'a1'},
+        {},
+        {name: 'a4'},
+        {name: 'a3'},
+      ].sort((a, b) => sortDeployments(a, b, 'name', 'asc'))
+      expect(arr[0].name).toBeUndefined()
+      expect(arr[1].name).toBe('a1')
+      expect(arr[2].name).toBe('a2')
+      expect(arr[3].name).toBe('a3')
+      expect(arr[4].name).toBe('a4')
+    })
+
+    it('sort 4 items, desc', () => {
+      const arr = [
+        {name: 'a2'},
+        {name: 'a1'},
+        {},
+        {name: 'a4'},
+        {name: 'a3'},
+      ].sort((a, b) => sortDeployments(a, b, 'name', 'desc'))
+      expect(arr[0].name).toBe('a4')
+      expect(arr[1].name).toBe('a3')
+      expect(arr[2].name).toBe('a2')
+      expect(arr[3].name).toBe('a1')
+      expect(arr[4].name).toBeUndefined()
+    })
+
+    it('both nulls', () => {
+      const arr = deployments.map((d) => { return {...d, name: null} }).sort((a, b) => sortDeployments(a, b, 'name', 'desc'))
+      expect(arr[0].name).toBeNull()
+      expect(arr[1].name).toBeNull()
+    })
+
+    it('both undefined', () => {
+      const arr = deployments.map((d) => { return {...d, name: undefined} }).sort((a, b) => sortDeployments(a, b, 'name', 'desc'))
+      expect(arr[0].name).toBeUndefined()
+      expect(arr[1].name).toBeUndefined()
+    })
+  })
+
+  describe('deploymentTime', () => {
+    it('should sort by deploymentTime ascending', () => {
+      const arr = [...deployments].sort((a, b) => sortDeployments(a, b, 'deploymentTime', 'asc'))
+      expect(arr[0].deploymentTime).toBe("2025-05-05T17:22:02.217+0200")
+      expect(arr[1].deploymentTime).toBe("2025-05-05T17:22:02.694+0200")
+    })
+
+    it('should sort by deploymentTime descending', () => {
+      const arr = [...deployments].sort((a, b) => sortDeployments(a, b, 'deploymentTime', 'desc'))
+      expect(arr[0].deploymentTime).toBe("2025-05-05T17:22:02.694+0200")
+      expect(arr[1].deploymentTime).toBe("2025-05-05T17:22:02.217+0200")
+    })
+  })
+})

--- a/frontend/src/components/deployment/DeploymentsView.vue
+++ b/frontend/src/components/deployment/DeploymentsView.vue
@@ -38,7 +38,7 @@
               </b-input-group-prepend>
               <b-input-group-append class="d-flex align-items-center">
                 <b-form-select size="sm" v-model="sorting.key" :options="sortingFields" class="mb-0"></b-form-select>
-                <b-button size="sm" v-hover-style="{ classes: ['text-primary'] }" variant="secondary-outline" @click="changeSortingOrder()" class="mdi mdi-18px ms-1"
+                <b-button size="sm" v-hover-style="{ classes: ['text-primary'] }" variant="secondary-outline" @click="changeSortingOrder()" class="mdi mdi-18px ms-1 border-0"
                   :class="sorting.order === 'desc' ? 'mdi-arrow-down' : 'mdi-arrow-up'"
                   :title="sorting.order === 'desc' ? $t('sorting.desc') : $t('sorting.asc')"></b-button>
               </b-input-group-append>

--- a/frontend/src/components/deployment/DeploymentsView.vue
+++ b/frontend/src/components/deployment/DeploymentsView.vue
@@ -116,7 +116,7 @@ export default {
       loading: true,
       deleteLoader: false,
       filter: this.$route.query.filter || '',
-      sorting: {},
+      sorting: { key: 'deploymentTime', order: 'asc' },
       cascadeDelete: true,
       resources: [],
       resourcesLoading: false,
@@ -126,7 +126,7 @@ export default {
   watch: {
     sorting: {
       handler: function() {
-        localStorage.setItem('deploymentSorting', JSON.stringify(this.sorting))
+        localStorage.setItem('cibseven:deploymentSorting', JSON.stringify(this.sorting))
       },
       deep: true
     }
@@ -159,11 +159,15 @@ export default {
     }
   },
   created: function () {
-    this.sorting = localStorage.getItem('deploymentSorting') ? JSON.parse(localStorage.getItem('deploymentSorting')) :
+    this.sorting = localStorage.getItem('cibseven:deploymentSorting') ? JSON.parse(localStorage.getItem('cibseven:deploymentSorting')) :
       { key: 'deploymentTime', order: 'asc' }
+    this.sorting.key = this.sortingFields.some((field) => field.value === this.sorting.key) ? this.sorting.key : 'deploymentTime'
+    this.sorting.order = ['asc','desc'].includes(this.sorting.order) ? this.sorting.order : 'asc'
+
     ProcessService.findDeployments().then(deployments => {
       deployments.forEach(d => {
         d.isSelected = false
+        d.name = d.name || d.id
       })
       this.deployments = deployments
       this.loading = false

--- a/frontend/src/components/deployment/utils.js
+++ b/frontend/src/components/deployment/utils.js
@@ -15,8 +15,9 @@
  *  limitations under the License.
  */
 export function sortDeployments(a, b, sorting, order) {
-  if (!a[sorting] && b[sorting]) return -1
-  else if (a[sorting] && !b[sorting]) return 1
+  if (!a[sorting] && !b[sorting]) return 0
+  else if (!a[sorting] && b[sorting]) return (order === 'asc') ? -1 : 1
+  else if (a[sorting] && !b[sorting]) return (order === 'asc') ? 1 : -1
   a = a[sorting].toLowerCase()
   b = b[sorting].toLowerCase()
   if (order === 'asc') return a < b ? -1 : a > b ? 1 : 0


### PR DESCRIPTION
This PR fixes next issue: the sorting variable was changed (see: https://github.com/cibseven/cibseven-webclient/pull/251/files#diff-4777927369db5d37fd8e7562a0aed7a39c32ba1700bf47f3878f2d89a2a8eaf2L107 ), but the old value was still stored in local storage (e.g., if the user had previously run version 2.0.0). As a result, sorting will not work correctly until the user clears their local storage.