### PR TITLE
feat(startProcess)!: introduce configurable access control for the "Start process" tile

### DIFF
--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -88,6 +88,7 @@
 			"filter": ["CREATE"]
 		},
 		"startProcess": {
+			"application": ["ALL"],
 			"processDefinition": ["READ", "CREATE_INSTANCE"],
 			"processInstance": ["CREATE"]
 		},

--- a/frontend/src/components/CibSeven.vue
+++ b/frontend/src/components/CibSeven.vue
@@ -31,7 +31,7 @@
         </div>
       </div>
 
-      <b-button v-if="$root.user && startableProcesses && $route.name === 'tasklist'" class="d-none d-sm-block py-0 me-3" variant="outline-secondary" :title="$t('start.startProcess.title')" @click="openStartProcess()">
+      <b-button v-if="$route.name === 'tasklist' && canStartProcesses" class="d-none d-sm-block py-0 me-3" variant="outline-secondary" :title="$t('start.startProcess.title')" @click="openStartProcess()">
         <span class="mdi mdi-18px mdi-rocket"><span class="d-none d-lg-inline">{{ $t('start.startProcess.title') }}</span></span>
       </b-button>
 
@@ -111,7 +111,7 @@
     <AboutModal ref="about"></AboutModal>
     <FeedbackModal ref="report" url="feedback" :email="$root.user && $root.user.email" @report="$refs.down.$emit('report', $event)"></FeedbackModal>
 
-    <GlobalEvents v-if="permissionsTaskList" @keydown.ctrl.left.prevent="$router.push('/seven/auth/start-process')"></GlobalEvents>
+    <GlobalEvents v-if="canStartProcesses" @keydown.ctrl.left.prevent="$router.push('/seven/auth/start-process')"></GlobalEvents>
     <GlobalEvents v-if="permissionsCockpit" @keydown.ctrl.right.prevent="$router.push('/seven/auth/processes/list')"></GlobalEvents>
     <GlobalEvents v-if="permissionsTaskList" @keydown.ctrl.down.prevent="$router.push('/seven/auth/tasks')"></GlobalEvents>
 
@@ -147,15 +147,22 @@ export default {
   },
   computed: {
     menuItems: function() {
-      return [{
-          show: this.permissionsTaskList && this.startableProcesses,
-          groupTitle: 'start.taskList.title',
+      return [
+        {
+          show: this.canStartProcesses,
+          groupTitle: 'start.startProcess.title',
           items: [{
               to: '/seven/auth/start-process',
               active: ['seven/auth/start-process'],
               tooltip: 'start.startProcess.tooltip',
               title: 'start.startProcess.title'
-            }, {
+            }
+          ]
+        },
+        {
+          show: this.permissionsTaskList,
+          groupTitle: 'start.taskList.title',
+          items: [{
               to: '/seven/auth/tasks',
               active: ['seven/auth/tasks'],
               tooltip: 'start.taskList.tooltip',
@@ -295,6 +302,9 @@ export default {
         return false
       })
       return title
+    },
+    canStartProcesses: function() {
+      return this.$root.user && this.applicationPermissions(this.$root.config.permissions.startProcess, 'startProcess')
     },
     permissionsTaskList: function() {
       return this.$root.user && this.applicationPermissions(this.$root.config.permissions.tasklist, 'tasklist')

--- a/frontend/src/components/start/StartView.vue
+++ b/frontend/src/components/start/StartView.vue
@@ -177,7 +177,7 @@ export default {
   computed: {
     tiles() {
       const tiles = []
-      if (this.applicationPermissions(this.$root.config.permissions.tasklist, 'tasklist') && this.startableProcesses) {
+      if (this.applicationPermissions(this.$root.config.permissions.startProcess, 'startProcess')) {
         tiles.push('startProcess')
       }
       if (this.applicationPermissions(this.$root.config.permissions.tasklist, 'tasklist')) {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -100,7 +100,7 @@ const appRoutes = [
         },
 
         // Start new process (end-user)
-        { path: 'start-process', name: 'start-process', beforeEnter: permissionsGuard('tasklist'),
+        { path: 'start-process', name: 'start-process', beforeEnter: permissionsGuard('startProcess'),
           component: StartProcessView
         },
 


### PR DESCRIPTION
BREAKING CHANGE: Access to the "Start process" tile is now disabled by default. Users and groups must be explicitly granted permission to view and use it via the `startProcess` application authorization.