### PR TITLE
fix: Update main class name for Spring Boot in Maven configuration

### DIFF
--- a/cibseven-webclient-web/pom.xml
+++ b/cibseven-webclient-web/pom.xml
@@ -195,7 +195,7 @@
 				<version>${version.spring.boot}</version>
 				<configuration>
 					<fork>true</fork>
-					<mainClass>org.cibseven.webapp.Application</mainClass>
+					<mainClass>org.cibseven.webapp.SevenWebclientApplication</mainClass>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
When packaging and running the application as a standalone Spring Boot application, the build failed to locate the main class due to an outdated reference in the pom.xml.

This PR updates the pom.xml to point to the correct main class, allowing the application to start successfully.
