### PR TITLE
fix(BpmnViewer): enhance watchers to include deep observation for statistics and activityInstance

### DIFF
--- a/frontend/src/components/process/BpmnViewer.vue
+++ b/frontend/src/components/process/BpmnViewer.vue
@@ -108,9 +108,15 @@ export default {
   },
   watch: {
     historicActivityStatistics: {
-      handler() {
-        this.drawDiagramState()
-      },
+      handler() { this.drawDiagramState() },
+      deep: true
+    },
+    statistics: {
+      handler() { if (this.viewer) this.drawDiagramState() },
+      deep: true
+    },
+    activityInstance: {
+      handler() { if (this.viewer) this.drawDiagramState() },
       deep: true
     },
     jobDefinitions: {


### PR DESCRIPTION
Root cause:
`drawDiagramState()` was only triggered by the `historicActivityStatistics` watcher. With history level set to "activity", incidents are not stored in history — they come from the statistics prop (process view) or `activityInstance.childTransitionInstances` (instance view). Since neither of these props had a watcher, the diagram was being redrawn before this data was available, so incident badges were never rendered.

Fix:
Added watchers on `statistics` and `activityInstance` to trigger a diagram redraw once this data is updated.