### PR TITLE
chore(IncidentsTable): correct historic incident determination logic

### DIFF
--- a/frontend/src/components/process/tables/IncidentsTable.vue
+++ b/frontend/src/components/process/tables/IncidentsTable.vue
@@ -419,11 +419,27 @@ export default {
       const id = this.isInstanceView ? this.instance.id : this.process.id
       this.loadIncidentsData(id, this.isInstanceView)
     },
+    isHistoricIncident(incident) {
+      if (incident.rootCauseIncidentConfiguration) {
+        switch (this.$root.config.camundaHistoryLevel) {
+          case 'none':
+          case 'activity':
+          case 'audit':
+            return false // always runtime view
+          case 'full':
+          default:
+            return true // always history view
+        }
+      }
+      else {
+        return !!incident.historyConfiguration
+      }
+    },
     showIncidentMessage: function(incident) {
-      const runtimeConfiguration = incident.configuration
+      const runtimeConfiguration = incident.configuration || incident.rootCauseIncidentConfiguration
       const historyConfiguration = incident.historyConfiguration || incident.rootCauseIncidentConfiguration
 
-      const isHistoric = !runtimeConfiguration
+      const isHistoric = this.isHistoricIncident(incident)
       const isExternalTask = incident.incidentType === 'failedExternalTask'
       const configuration = isHistoric ? historyConfiguration : runtimeConfiguration
 


### PR DESCRIPTION
relates to: fix(IncidentsTable): use runtime configuration to see stacktrace for incident with "activity" history level ([#927](https://github.com/cibseven/cibseven-webclient/issues/927))
id: ac87da46f5b93fd21fbcca54d0944028e7d47099