### PR TITLE
chore(translations): Update german translation for 'scope'

### DIFF
--- a/frontend/src/assets/translations_de.json
+++ b/frontend/src/assets/translations_de.json
@@ -281,7 +281,7 @@
 			"value": "Wert",
 			"valueSerialized": "Serialisierter Wert",
 			"actions": "Aktionen",
-			"scope": "Umfang",
+			"scope": "Gültigkeitsbereich",
 			"activityInstanceId": "Aktivitätsinstanz-ID",
 			"objectTypeName": "Objekttypname",
 			"serializationDataFormat": "Serialisierungsdatenformat",

--- a/frontend/src/assets/translations_de.json
+++ b/frontend/src/assets/translations_de.json
@@ -281,7 +281,7 @@
 			"value": "Wert",
 			"valueSerialized": "Serialisierter Wert",
 			"actions": "Aktionen",
-			"scope": "Gültigkeitsbereich",
+			"scope": "Bereich",
 			"activityInstanceId": "Aktivitätsinstanz-ID",
 			"objectTypeName": "Objekttypname",
 			"serializationDataFormat": "Serialisierungsdatenformat",


### PR DESCRIPTION
The new translation "Bereich" better fits the context of a variable