### PR TITLE
Ldap enhancements

### DIFF
--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/auth/LdapUserProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/auth/LdapUserProvider.java
@@ -60,6 +60,7 @@ public class LdapUserProvider extends BaseUserProvider<StandardLogin> {
 	@Value("${cibseven.webclient.ldap.folder:}") String ldapFolder;
 	@Value("${cibseven.webclient.ldap.userNameAttribute:}") String ldapNameAttribute;
 	@Value("${cibseven.webclient.ldap.userDisplayNameAttribute:}") String ldapDisplayNameAttribute;
+	@Value("${cibseven.webclient.ldap.userClass:}") String ldapUserClass;
 	@Value("#{'${cibseven.webclient.ldap.attributes.filters:samAccountName;name}'.split(';\\s*')}") List<String> ldapAttributesFilters;
 	@Value("${cibseven.webclient.ldap.modifiedDateFormat:}") String ldapModifiedDateFormat;
 	@Value("${cibseven.webclient.ldap.countLimit:400}") int ldapCountLimit;
@@ -85,9 +86,9 @@ public class LdapUserProvider extends BaseUserProvider<StandardLogin> {
 			SearchControls searchControls = new SearchControls();
 			searchControls.setCountLimit(ldapCountLimit);
 			searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-			NamingEnumeration<SearchResult> results = initialDirContext.search(ldapFolder, "(&(" + ldapNameAttribute + "=" + login.getUsername() + ")(objectClass=person))", searchControls);
+			NamingEnumeration<SearchResult> results = initialDirContext.search(ldapFolder, "(&(" + ldapNameAttribute + "=" + login.getUsername() + ")(objectClass=" + ldapUserClass + "))", searchControls);
 			if(!results.hasMore()) {
-				throw new LoginException("[ERROR][LdapUserProvider] login not user found with the following username: " + login.getUsername());
+				throw new LoginException("[ERROR][LdapUserProvider] login not user found with the following username: " + login.getUsername() + " and object class: " + ldapUserClass);
 			}
 			SearchResult result = results.next();
 			CIBUser user =  new CIBUser(result.getAttributes().get(ldapNameAttribute).get().toString());

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/auth/LdapUserProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/auth/LdapUserProvider.java
@@ -76,17 +76,19 @@ public class LdapUserProvider extends BaseUserProvider<StandardLogin> {
 	@Override
 	public CIBUser login(StandardLogin login, HttpServletRequest rq) {	
         try {
+			String fullUserDN = getFullUserDN(login.getUsername());
 			Hashtable<String, String> environment = new Hashtable<String, String>();
 	        environment.put(javax.naming.Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
 	        environment.put(javax.naming.Context.PROVIDER_URL, serverURL);
-	        environment.put(javax.naming.Context.SECURITY_PRINCIPAL, getFullUserDN(login.getUsername()));
+	        environment.put(javax.naming.Context.SECURITY_PRINCIPAL, fullUserDN);
 	        environment.put(javax.naming.Context.SECURITY_CREDENTIALS, login.getPassword());
 	        environment.put(javax.naming.Context.REFERRAL, ldapFollowReferrals);
 			InitialDirContext initialDirContext = new InitialDirContext(environment);
+			// do not use configured LDAP base, but full DN of logging in user, because normal users generally are not allowed to do LDAP searches
 			SearchControls searchControls = new SearchControls();
 			searchControls.setCountLimit(ldapCountLimit);
-			searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-			NamingEnumeration<SearchResult> results = initialDirContext.search(ldapFolder, "(&(" + ldapNameAttribute + "=" + login.getUsername() + ")(objectClass=" + ldapUserClass + "))", searchControls);
+			searchControls.setSearchScope(SearchControls.OBJECT_SCOPE);
+			NamingEnumeration<SearchResult> results = initialDirContext.search(fullUserDN, "(&(" + ldapNameAttribute + "=" + login.getUsername() + ")(objectClass=" + ldapUserClass + "))", searchControls);
 			if(!results.hasMore()) {
 				throw new LoginException("[ERROR][LdapUserProvider] login not user found with the following username: " + login.getUsername() + " and object class: " + ldapUserClass);
 			}

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/auth/LdapUserProvider.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/auth/LdapUserProvider.java
@@ -94,7 +94,11 @@ public class LdapUserProvider extends BaseUserProvider<StandardLogin> {
 			}
 			SearchResult result = results.next();
 			CIBUser user =  new CIBUser(result.getAttributes().get(ldapNameAttribute).get().toString());
-			user.setDisplayName(result.getAttributes().get(ldapDisplayNameAttribute).get().toString());
+			if (result.getAttributes().get(ldapDisplayNameAttribute) != null) {
+				user.setDisplayName(result.getAttributes().get(ldapDisplayNameAttribute).get().toString());
+			} else {
+				log.debug("User " + login.getUsername() + " does not have attribute " + ldapDisplayNameAttribute + " defined.");
+			}
 			
 			// Set engine from request header
 			EngineTokenUtils.setEngineFromRequest(user, rq);

--- a/cibseven-webclient-web/src/main/resources/application.yaml
+++ b/cibseven-webclient-web/src/main/resources/application.yaml
@@ -66,6 +66,7 @@ cibseven:
     ldap:
       url: ldap://ldap.cibseven.org
       folder: DC=cibseven,DC=org
+      userClass: person
       userNameAttribute: samAccountName
       userDisplayNameAttribute: name
       modifiedDateFormat: yyyyMMddHHmmss.SX

--- a/helm/cibseven-webclient/values.yaml
+++ b/helm/cibseven-webclient/values.yaml
@@ -69,6 +69,7 @@ application:
         userDisplayNameAttribute: ""
         modifiedDateFormat: ""
         followReferrals: ""
+        userClass: ""
         user: ""
         password: ""
 


### PR DESCRIPTION
Enhancement and fixes for LdapUserProvider:
1. do not perform full LDAP search from configured base when verifying whether user can login
    1. this is not comonly allowed for general users
    1. instead of that retrieve only currently logged in user 
1. allow to modify LDAP objectClass for users instead of current hardcoded value
1. do not fail when attribute for display name is not defined for user that is trying to login

This way it makes the LdapUserProvider usable in more environments.