### PR TITLE
chore: update version of cibseven-modeler to 1.0.0-dev.12

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.4",
+  "version": "2.2.0-dev.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cibseven-components",
-      "version": "2.2.0-dev.4",
+      "version": "2.2.0-dev.5",
       "dependencies": {
         "@bpmn-io/form-js": "1.21.3",
         "@cib/common-frontend": "1.0.3-dev.16",
@@ -16,7 +16,7 @@
         "bootstrap": "5.3.8",
         "bpm-sdk": "2.1.1",
         "bpmn-js": "18.14.0",
-        "cibseven-modeler": "1.0.0-dev.11",
+        "cibseven-modeler": "1.0.0-dev.12",
         "dmn-js": "17.7.0",
         "js-sha256": "0.11.1",
         "moment": "2.30.1",
@@ -51,7 +51,7 @@
       "peerDependencies": {
         "axios": "^1.15.2",
         "bootstrap": "^5.3.8",
-        "cibseven-modeler": "^1.0.0-dev.11",
+        "cibseven-modeler": "^1.0.0-dev.12",
         "vue": "^3.5.33",
         "vue-i18n": "^11.4.0",
         "vue-router": "^5.0.6"
@@ -4393,9 +4393,9 @@
       }
     },
     "node_modules/cibseven-modeler": {
-      "version": "1.0.0-dev.11",
-      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.11.tgz",
-      "integrity": "sha512-MZZbbDh35BPvsZezOOe8jSLNyalzwyACdld00Q/kjR3uDaLJxVKGZRVaadohNy6dFhKXP9w7H3J6Woy0cGVwcA==",
+      "version": "1.0.0-dev.12",
+      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.12.tgz",
+      "integrity": "sha512-aAJTxthgKrfFPo7Fob/Y/AzebIGYsUJnxWIv9VVXXJ2n6QXfAQaf1m8OyxNJpr+dZYxSAsuQ7MtUQEN2Co3+3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bpmn-io/dmn-migrate": "0.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.4",
+  "version": "2.2.0-dev.5",
   "type": "module",
   "license": "",
   "main": "./src/main.js",
@@ -46,7 +46,7 @@
     "bootstrap": "5.3.8",
     "bpm-sdk": "2.1.1",
     "bpmn-js": "18.14.0",
-    "cibseven-modeler": "1.0.0-dev.11",
+    "cibseven-modeler": "1.0.0-dev.12",
     "dmn-js": "17.7.0",
     "js-sha256": "0.11.1",
     "moment": "2.30.1",
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "axios": "^1.15.2",
     "bootstrap": "^5.3.8",
-    "cibseven-modeler": "^1.0.0-dev.11",
+    "cibseven-modeler": "^1.0.0-dev.12",
     "vue": "^3.5.33",
     "vue-i18n": "^11.4.0",
     "vue-router": "^5.0.6"


### PR DESCRIPTION
 in package.json and package-lock.json

bump frontend version to 2.2.0-dev.5