### PR TITLE
chore: update version of cibseven-modeler to 1.0.0-dev.14

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.6",
+  "version": "2.2.0-dev.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cibseven-components",
-      "version": "2.2.0-dev.6",
+      "version": "2.2.0-dev.7",
       "dependencies": {
         "@bpmn-io/form-js": "1.21.3",
         "@cib/common-frontend": "1.0.3-dev.16",
@@ -16,7 +16,7 @@
         "bootstrap": "5.3.8",
         "bpm-sdk": "2.1.1",
         "bpmn-js": "18.14.0",
-        "cibseven-modeler": "1.0.0-dev.13",
+        "cibseven-modeler": "1.0.0-dev.14",
         "dmn-js": "17.7.0",
         "js-abbreviation-number": "1.4.0",
         "js-sha256": "0.11.1",
@@ -52,7 +52,7 @@
       "peerDependencies": {
         "axios": "^1.15.2",
         "bootstrap": "^5.3.8",
-        "cibseven-modeler": "^1.0.0-dev.13",
+        "cibseven-modeler": "^1.0.0-dev.14",
         "vue": "^3.5.33",
         "vue-i18n": "^11.4.0",
         "vue-router": "^5.0.6"
@@ -4337,9 +4337,9 @@
       }
     },
     "node_modules/cibseven-modeler": {
-      "version": "1.0.0-dev.13",
-      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.13.tgz",
-      "integrity": "sha512-/gKIo4Hya7BQJunQngJT07Yt2AA+KG+uli/akQiadtm0tw0SsJABmxVQXYtbmu6wWxvdRL4doR1Pb/fiynAF9A==",
+      "version": "1.0.0-dev.14",
+      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.14.tgz",
+      "integrity": "sha512-xLHiuDDCyBVc3UduV338ZomDQQQkNtJTdScUdo9InDaY1xLOdWoURtTRiSglLyV+VBDy9BGYfdigtm7HxbS/wg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bpmn-io/dmn-migrate": "0.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.6",
+  "version": "2.2.0-dev.7",
   "type": "module",
   "license": "",
   "main": "./src/main.js",
@@ -46,7 +46,7 @@
     "bootstrap": "5.3.8",
     "bpm-sdk": "2.1.1",
     "bpmn-js": "18.14.0",
-    "cibseven-modeler": "1.0.0-dev.13",
+    "cibseven-modeler": "1.0.0-dev.14",
     "dmn-js": "17.7.0",
     "js-abbreviation-number": "1.4.0",
     "js-sha256": "0.11.1",
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "axios": "^1.15.2",
     "bootstrap": "^5.3.8",
-    "cibseven-modeler": "^1.0.0-dev.13",
+    "cibseven-modeler": "^1.0.0-dev.14",
     "vue": "^3.5.33",
     "vue-i18n": "^11.4.0",
     "vue-router": "^5.0.6"


### PR DESCRIPTION
in package.json and package-lock.json

bump frontend version to 2.2.0-dev.7