### PR TITLE
feat(BpmnViewer): render element-template icons in cockpit viewer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "bootstrap": "5.3.8",
         "bpm-sdk": "2.1.1",
         "bpmn-js": "18.14.0",
-        "cibseven-modeler": "1.0.0-dev.15",
+        "cibseven-modeler": "1.0.0-dev.16",
         "dmn-js": "17.7.0",
         "js-abbreviation-number": "1.4.0",
         "js-sha256": "0.11.1",
@@ -4357,9 +4357,9 @@
       }
     },
     "node_modules/cibseven-modeler": {
-      "version": "1.0.0-dev.15",
-      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.15.tgz",
-      "integrity": "sha512-NmBcTIaBwOIYqFjucrdt94owtixRXiZBcKw4Y7jxKQZKTdqSv3UuvGzb+JZN5+Gy7yc8NESAuuzVQyShTQLgCg==",
+      "version": "1.0.0-dev.16",
+      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.16.tgz",
+      "integrity": "sha512-D5c+S+WvUWBQAxklaV8B/KevELXpvD/kUWaSXMyt9r3/70+VFqf9qlyaS8FwtMlBfMd6v5U+RvitQ8w6pqoOug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bpmn-io/dmn-migrate": "0.7.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.8",
+  "version": "2.2.0-dev.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cibseven-components",
-      "version": "2.2.0-dev.8",
+      "version": "2.2.0-dev.9",
       "dependencies": {
         "@bpmn-io/form-js": "1.21.3",
         "@cib/common-frontend": "1.0.3-dev.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "bootstrap": "5.3.8",
     "bpm-sdk": "2.1.1",
     "bpmn-js": "18.14.0",
-    "cibseven-modeler": "1.0.0-dev.15",
+    "cibseven-modeler": "1.0.0-dev.16",
     "dmn-js": "17.7.0",
     "js-abbreviation-number": "1.4.0",
     "js-sha256": "0.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.8",
+  "version": "2.2.0-dev.9",
   "type": "module",
   "license": "",
   "main": "./src/main.js",

--- a/frontend/src/components/process/BpmnViewer.vue
+++ b/frontend/src/components/process/BpmnViewer.vue
@@ -50,6 +50,7 @@ import { BWaitingBox } from '@cib/common-frontend'
 import { mapActions, mapGetters } from 'vuex'
 import { HistoryService } from '@/services.js'
 import { abbreviateNumber } from 'js-abbreviation-number'
+import ElementTemplateIconRendererModule from '@/components/process/ElementTemplateIconRenderer.js'
 
 const interactionTypes = [
   // Tasks
@@ -103,6 +104,7 @@ export default {
     ...mapGetters(['highlightedElement', 'getHistoricActivityStatistics']),
     ...mapGetters('calledProcessDefinitions', ['getStaticCalledProcessDefinitions']),
     ...mapGetters('job', ['jobDefinitions']),
+    ...mapGetters('modeler/elementTemplates', { allElementTemplateContents: 'allElementTemplateContents' }),
     historicActivityStatistics() {
       return this.getHistoricActivityStatistics(this.processDefinitionId)
     }
@@ -132,21 +134,54 @@ export default {
     highlightedElement: function(newVal) {
       this.highlightElement(newVal)
     },
+    allElementTemplateContents: {
+      handler() { this.applyElementTemplateIcons() },
+      deep: true
+    }
   },
   mounted: function() {
-    this.viewer = new NavigatedViewer({ container: this.$refs.diagram })
+    this.viewer = new NavigatedViewer({
+      container: this.$refs.diagram,
+      additionalModules: [ElementTemplateIconRendererModule]
+    })
     this.viewer.on('import.done', () => {
       this.drawDiagramState()
       this.attachEventListeners()
+      this.applyElementTemplateIcons()
       //Small timer so the diagram is fully rendered before setting it ready
       setTimeout(() => {
         this.setDiagramReady(true)
       }, 500)
     })
+    this.ensureElementTemplatesLoaded()
   },
   methods: {
     ...mapActions(['selectActivity', 'clearActivitySelection', 'setHighlightedElement', 'loadActivitiesInstanceHistory', 'getProcessById']),
     ...mapActions('diagram', ['setDiagramReady']),
+    ...mapActions('modeler/elementTemplates', ['fetchAllElementTemplates']),
+    ensureElementTemplatesLoaded: function() {
+      if (this.allElementTemplateContents && this.allElementTemplateContents.length > 0) return
+      this.fetchAllElementTemplates().catch(err => {
+        console.warn('BpmnViewer: failed to load element templates for icon rendering', err)
+      })
+    },
+    applyElementTemplateIcons: function() {
+      if (!this.viewer) return
+      let registry
+      try {
+        registry = this.viewer.get('elementTemplateIcons')
+      } catch {
+        return
+      }
+      const contents = this.allElementTemplateContents || []
+      const iconMap = new Map()
+      contents.forEach(template => {
+        const id = template && template.id
+        const icon = template && template.icon && template.icon.contents
+        if (id && icon) iconMap.set(id, icon)
+      })
+      registry.setIcons(iconMap)
+    },
     showDiagram: function(xml, selectedActivityId = null) {
       this.setDiagramReady(false)
       this.loader = true

--- a/frontend/src/components/process/ElementTemplateIconRenderer.js
+++ b/frontend/src/components/process/ElementTemplateIconRenderer.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Custom bpmn-js renderer that draws element-template icons on top of
+// activities/events in a read-only viewer (cockpit). It overrides the default
+// BpmnRenderer with HIGH_PRIORITY for elements that have a known template id,
+// reading the icon data from a runtime registry populated by BpmnViewer.vue
+// (so that NavigatedViewer does not have to mutate businessObjects after
+// XML import).
+
+import inherits from 'inherits-browser'
+import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer'
+import { getBusinessObject, is, isAny } from 'bpmn-js/lib/util/ModelUtil'
+import { isLabel } from 'bpmn-js/lib/util/LabelUtil'
+import { append as svgAppend, attr as svgAttr, create as svgCreate } from 'tiny-svg'
+
+const HIGH_PRIORITY = 1250
+const ICON_SIZE = 18
+
+function ElementTemplateIconRenderer(eventBus, bpmnRenderer, elementTemplateIcons) {
+  this._bpmnRenderer = bpmnRenderer
+  this._elementTemplateIcons = elementTemplateIcons
+  BaseRenderer.call(this, eventBus, HIGH_PRIORITY)
+}
+
+inherits(ElementTemplateIconRenderer, BaseRenderer)
+
+ElementTemplateIconRenderer.prototype._getIcon = function(element) {
+  const bo = getBusinessObject(element)
+  const templateId = bo && bo.get && bo.get('camunda:modelerTemplate')
+  if (!templateId) return null
+  return this._elementTemplateIcons.getIcon(templateId)
+}
+
+ElementTemplateIconRenderer.prototype.canRender = function(element) {
+  if (isLabel(element)) return false
+  return isAny(element, ['bpmn:Activity', 'bpmn:Event']) && !!this._getIcon(element)
+}
+
+ElementTemplateIconRenderer.prototype.drawShape = function(parentGfx, element, attrs = {}) {
+  const handlerType = [
+    'bpmn:BoundaryEvent',
+    'bpmn:CallActivity',
+    'bpmn:EndEvent',
+    'bpmn:IntermediateCatchEvent',
+    'bpmn:IntermediateThrowEvent',
+    'bpmn:StartEvent',
+    'bpmn:Task',
+    'bpmn:AdHocSubProcess',
+    'bpmn:Transaction',
+    'bpmn:SubProcess'
+  ].find(t => is(element, t))
+
+  const renderer = handlerType && this._bpmnRenderer.handlers[handlerType]
+  if (!renderer) return this._bpmnRenderer.drawShape(parentGfx, element)
+
+  const gfx = renderer(parentGfx, element, { ...attrs, renderIcon: false })
+
+  const icon = this._getIcon(element)
+  const padding = is(element, 'bpmn:Activity')
+    ? { x: 5, y: 5 }
+    : { x: (element.width - ICON_SIZE) / 2, y: (element.height - ICON_SIZE) / 2 }
+
+  const img = svgCreate('image')
+  svgAttr(img, { href: icon, width: ICON_SIZE, height: ICON_SIZE, ...padding })
+  svgAppend(parentGfx, img)
+
+  return gfx
+}
+
+ElementTemplateIconRenderer.$inject = ['eventBus', 'bpmnRenderer', 'elementTemplateIcons']
+
+// Registry service: holds the templateId → icon dataURL map. BpmnViewer.vue
+// updates this after fetching templates and then fires `elements.changed`
+// to trigger a re-render of affected shapes.
+function ElementTemplateIcons(eventBus, elementRegistry) {
+  this._eventBus = eventBus
+  this._elementRegistry = elementRegistry
+  this._icons = new Map()
+}
+
+ElementTemplateIcons.prototype.getIcon = function(templateId) {
+  return this._icons.get(templateId) || null
+}
+
+ElementTemplateIcons.prototype.setIcons = function(iconsMap) {
+  this._icons = iconsMap instanceof Map ? iconsMap : new Map(Object.entries(iconsMap || {}))
+  // Re-render every element that references a template id, so the renderer
+  // re-evaluates canRender/drawShape with the new icons available.
+  const affected = this._elementRegistry.filter(el => {
+    const bo = el.businessObject
+    return bo && bo.get && bo.get('camunda:modelerTemplate')
+  })
+  if (affected.length) {
+    this._eventBus.fire('elements.changed', { elements: affected })
+  }
+}
+
+ElementTemplateIcons.$inject = ['eventBus', 'elementRegistry']
+
+export default {
+  __init__: ['elementTemplateIconRenderer'],
+  elementTemplateIconRenderer: ['type', ElementTemplateIconRenderer],
+  elementTemplateIcons: ['type', ElementTemplateIcons]
+}


### PR DESCRIPTION
## Summary
- Adds a custom `ElementTemplateIconRenderer` bpmn-js module that overlays element-template icons on activities and events in the read-only `NavigatedViewer` used by the cockpit, mirroring the look the modeler already provides.
- Registers the module on `BpmnViewer.vue` mount, fetches all element templates via the `modeler/elementTemplates` Vuex store, and pushes the `templateId → icon` map into a new `elementTemplateIcons` registry service. The renderer reads from that registry and re-renders affected shapes via an `elements.changed` event when icons arrive or change.
- Bumps `cibseven-components` to `2.2.0-dev.9`.
