### PR TITLE
fix(modeler): keep default task marker visible with template icon

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.10",
+  "version": "2.2.0-dev.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cibseven-components",
-      "version": "2.2.0-dev.10",
+      "version": "2.2.0-dev.11",
       "dependencies": {
         "@bpmn-io/form-js": "1.21.3",
         "@cib/bootstrap-theme": "1.0.0-dev.0",
@@ -17,7 +17,7 @@
         "bootstrap": "5.3.8",
         "bpm-sdk": "2.1.1",
         "bpmn-js": "18.14.0",
-        "cibseven-modeler": "1.0.0-dev.17",
+        "cibseven-modeler": "1.0.0-dev.18",
         "dmn-js": "17.7.0",
         "js-abbreviation-number": "1.4.0",
         "js-sha256": "0.11.1",
@@ -4350,9 +4350,9 @@
       }
     },
     "node_modules/cibseven-modeler": {
-      "version": "1.0.0-dev.17",
-      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.17.tgz",
-      "integrity": "sha512-J4FPHfulnxIcPRHHS2Cr3jkxQsBCFAnd6j2MPVeJ4OzNZ24W6VKA6P4YcS1DFzoo4BfLOGNT0Let8KittMtfLg==",
+      "version": "1.0.0-dev.18",
+      "resolved": "https://artifacts.cibseven.org/repository/npm-group/cibseven-modeler/-/cibseven-modeler-1.0.0-dev.18.tgz",
+      "integrity": "sha512-EvO+JbK62Ti/AQ19VUUVKLfqAItiP+/kG4hqCFOY90YWphS55hwVN1QWGu9ZnTseNDu/Iad+fH1TWWA70dcyew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bpmn-io/dmn-migrate": "0.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cibseven-components",
-  "version": "2.2.0-dev.10",
+  "version": "2.2.0-dev.11",
   "type": "module",
   "license": "",
   "main": "./src/main.js",
@@ -47,7 +47,7 @@
     "bootstrap": "5.3.8",
     "bpm-sdk": "2.1.1",
     "bpmn-js": "18.14.0",
-    "cibseven-modeler": "1.0.0-dev.17",
+    "cibseven-modeler": "1.0.0-dev.18",
     "dmn-js": "17.7.0",
     "js-abbreviation-number": "1.4.0",
     "js-sha256": "0.11.1",

--- a/frontend/src/components/process/ElementTemplateIconRenderer.js
+++ b/frontend/src/components/process/ElementTemplateIconRenderer.js
@@ -65,14 +65,26 @@ ElementTemplateIconRenderer.prototype.drawShape = function(parentGfx, element, a
     'bpmn:SubProcess'
   ].find(t => is(element, t))
 
-  const renderer = handlerType && this._bpmnRenderer.handlers[handlerType]
+  // Prefer the specific handler (e.g. 'bpmn:UserTask') so the task-type
+  // marker — the user figure on a user task, gears on a service task — is
+  // drawn. Falling back to the base-type handler (e.g. 'bpmn:Task') would
+  // draw a plain task with no marker. Keep the handlerType fallback for
+  // custom subclasses that don't register their own handler.
+  const handlers = this._bpmnRenderer.handlers
+  const renderer = handlers[element.type] || (handlerType && handlers[handlerType])
   if (!renderer) return this._bpmnRenderer.drawShape(parentGfx, element)
 
-  const gfx = renderer(parentGfx, element, { ...attrs, renderIcon: false })
+  const isActivity = is(element, 'bpmn:Activity')
+  // For activities, keep the default task-type marker (user figure, gears, ...)
+  // visible and paint the template icon in the opposite (top-right) corner.
+  // For events there isn't room for both, so we still replace the default
+  // marker with the template icon in the center.
+  const rendererAttrs = isActivity ? attrs : { ...attrs, renderIcon: false }
+  const gfx = renderer(parentGfx, element, rendererAttrs)
 
   const icon = this._getIcon(element)
-  const padding = is(element, 'bpmn:Activity')
-    ? { x: 5, y: 5 }
+  const padding = isActivity
+    ? { x: element.width - ICON_SIZE - 5, y: 5 }
     : { x: (element.width - ICON_SIZE) / 2, y: (element.height - ICON_SIZE) / 2 }
 
   const img = svgCreate('image')


### PR DESCRIPTION
Render the applied element-template icon in the opposite (top-right) corner on activities so the default task-type marker (user figure on user tasks, gears on service tasks, ...) stays visible as a reference instead of being replaced. Events still replace-and-center because a 36 px circle has no room for two icons.

Also fix the bpmn-js handler lookup: the .find() over base types returns 'bpmn:Task' first for a UserTask, and handlers['bpmn:Task'] is the plain task handler with no marker. Prefer handlers[element.type] and fall back to handlerType only for custom subclasses.