### PR TITLE
fix: don't pack frontend as public/ into classes.jar (#732)

### DIFF
--- a/cibseven-webclient-web-sb4/pom.xml
+++ b/cibseven-webclient-web-sb4/pom.xml
@@ -157,6 +157,10 @@
 						<phase>package</phase>
 						<configuration>
 							<classifier>classes</classifier>
+							<excludes>
+							    <!-- Do not pack the public/ folder into the classes jar, as that causes trouble when embedding the engine. -->
+								<exclude>public/**</exclude>
+							</excludes>
 						</configuration>
 					</execution>
 				</executions>

--- a/cibseven-webclient-web/pom.xml
+++ b/cibseven-webclient-web/pom.xml
@@ -95,6 +95,10 @@
 						<phase>package</phase>
 						<configuration>
 							<classifier>classes</classifier>
+							<excludes>
+							    <!-- Do not pack the public/ folder into the classes jar, as that causes trouble when embedding the engine. -->
+								<exclude>public/**</exclude>
+							</excludes>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
The classes jar is used to embed the webclient into the full process engine. In that case, the frontend stuff is taken from cibseven-webapp-webjar so this isn't needed. Having stuff in /public under the root folder messes things up when embedding the process engine into other applications.