### PR TITLE
fix(modeler): defer ElementTemplateLoader to context-refresh (CIB7-1420)

### DIFF
--- a/cibseven-webclient-core/src/main/java/org/cibseven/modeler/util/ElementTemplateLoader.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/modeler/util/ElementTemplateLoader.java
@@ -25,8 +25,9 @@ import org.cibseven.modeler.config.ElementTemplateProperties;
 import org.cibseven.modeler.model.ElementTemplate;
 import org.cibseven.modeler.model.ElementTemplateOrigin;
 import org.cibseven.modeler.repository.ElementTemplateRepository;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Component;
@@ -45,7 +46,7 @@ import lombok.extern.slf4j.Slf4j;
     matchIfMissing = false
 )
 @Slf4j
-public class ElementTemplateLoader implements InitializingBean {
+public class ElementTemplateLoader {
 
 	private final ObjectMapper mapper;
 	private final ElementTemplateRepository elementTemplateRepository;
@@ -63,8 +64,15 @@ public class ElementTemplateLoader implements InitializingBean {
 		this.resourcePatternResolver = resourcePatternResolver;
 	}
 
-	@Override
-	public void afterPropertiesSet() throws Exception {
+	// Defer to context refresh: the engine creates the MOD_* tables during ProcessEngine
+	// bootstrap (ProcessEngineFactoryBean.getObject -> dbSchemaCreateModeler), which runs
+	// while singletons are being instantiated. Querying them in afterPropertiesSet races
+	// the engine and fails on a fresh database.
+	@EventListener
+	public void onContextRefreshed(ContextRefreshedEvent event) {
+		if (event.getApplicationContext().getParent() != null) {
+			return;
+		}
 		transactionTemplate.executeWithoutResult(status -> populateElementTemplatesDatabase());
 	}
 


### PR DESCRIPTION
## Summary
- `ElementTemplateLoader` was implementing `InitializingBean` and querying `mod_element_templates` during `preInstantiateSingletons`, before the engine's `ProcessEngineFactoryBean` had a chance to run `dbSchemaCreateModeler()` and create the `MOD_*` tables. On a fresh database the loader hit a missing table and poisoned context startup with an `UnexpectedRollbackException` cascade.
- Moves the seeding to `@EventListener(ContextRefreshedEvent.class)` with a root-context guard, so it runs after all eager singletons have been instantiated (including the beans that pull in `ProcessEngine`, which forces the FactoryBean to resolve and the schema to be created).
- Keeps the webclient decoupled from any engine bean name — important for deployments against a remote engine, where no `processEngine` bean exists locally.

## Why not other approaches
- `@DependsOn("processEngine")` — couples the webclient to the engine bean and breaks remote-engine deployments.
- `ddl-auto: update` / Flyway in webclient — the `MOD_*` schema is owned by the engine (`activiti.<dialect>.create.modeler.sql`); duplicating it would conflict.
- Engine-side eager schema-create — wider blast radius for what is fundamentally a webclient lifecycle bug.

## Jira
- https://helpdesk.cib.de/browse/CIB7-1420 (relates to CIB7-1346)

## Test plan
- [ ] Boot `cibseven-run` (docker-ee image, MySQL, fresh DB) — startup succeeds, `MOD_ELEMENT_TEMPLATES` is populated from bundled connector JARs.
- [ ] Boot against a database where `MOD_*` already exist — startup still succeeds, existing templates are upserted.
- [ ] Run the webclient against a remote engine (no local `processEngine` bean) — startup still succeeds; no element-template seeding occurs but no errors either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)