### PR TITLE
fix(wildfly): dependencies due to directProvider

### DIFF
--- a/cibseven-webclient-web-sb4/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/cibseven-webclient-web-sb4/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -3,6 +3,8 @@
   <deployment>
     <dependencies>
       <module name="org.jboss.logging"/>
+      <module name="org.cibseven.bpm.cibseven-engine"/>
+      <module name="org.cibseven.bpm.dmn.cibseven-engine-dmn"/>
       <system>
         <paths>
           <path name="jdk/net"/>

--- a/cibseven-webclient-web/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/cibseven-webclient-web/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -3,6 +3,8 @@
   <deployment>
     <dependencies>
       <module name="org.jboss.logging"/>
+      <module name="org.cibseven.bpm.cibseven-engine"/>
+      <module name="org.cibseven.bpm.dmn.cibseven-engine-dmn"/>
       <system>
         <paths>
           <path name="jdk/net"/>


### PR DESCRIPTION
WildFly uses modular classloading so we must declare a dependency that exposes the classes of external deployments.