### PR TITLE
feat(wildfly): discover ai-agent element-templates in the modeler (CIB7-1445)

### DIFF
--- a/cibseven-webclient-web-sb4/src/main/runtime/wildfly/webapp/WEB-INF/classes/application-wildfly.yaml
+++ b/cibseven-webclient-web-sb4/src/main/runtime/wildfly/webapp/WEB-INF/classes/application-wildfly.yaml
@@ -6,3 +6,12 @@ cibseven:
   webclient:
     modeler:
       enabled: true
+      # Element-template discovery for the modeler. classpath*: picks up templates
+      # bundled in connector modules (e.g. the ai-agent module, made visible to this
+      # WAR via the optional dependency in jboss-deployment-structure.xml); the file:
+      # entry lets operators drop their own JSONs into
+      # <standalone>/configuration/element-templates/.
+      templates:
+        paths:
+          - "classpath*:element-templates/*.json"
+          - "file:${jboss.server.config.dir}/element-templates/*.json"

--- a/cibseven-webclient-web-sb4/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/cibseven-webclient-web-sb4/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -5,6 +5,10 @@
       <module name="org.jboss.logging"/>
       <module name="org.cibseven.bpm.cibseven-engine"/>
       <module name="org.cibseven.bpm.dmn.cibseven-engine-dmn"/>
+      <!-- ai-agent connector module: optional so the WAR still deploys when the
+           module is absent (AI disabled). Gives the modeler visibility to the
+           connector's bundled /element-templates/*.json (CIB7-1445). -->
+      <module name="org.cibseven.connect.cibseven-connect-ai-agent" optional="true"/>
       <system>
         <paths>
           <path name="jdk/net"/>

--- a/cibseven-webclient-web/src/main/runtime/wildfly/webapp/WEB-INF/classes/application-wildfly.yaml
+++ b/cibseven-webclient-web/src/main/runtime/wildfly/webapp/WEB-INF/classes/application-wildfly.yaml
@@ -6,3 +6,12 @@ cibseven:
   webclient:
     modeler:
       enabled: true
+      # Element-template discovery for the modeler. classpath*: picks up templates
+      # bundled in connector modules (e.g. the ai-agent module, made visible to this
+      # WAR via the optional dependency in jboss-deployment-structure.xml); the file:
+      # entry lets operators drop their own JSONs into
+      # <standalone>/configuration/element-templates/.
+      templates:
+        paths:
+          - "classpath*:element-templates/*.json"
+          - "file:${jboss.server.config.dir}/element-templates/*.json"

--- a/cibseven-webclient-web/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/cibseven-webclient-web/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -5,6 +5,10 @@
       <module name="org.jboss.logging"/>
       <module name="org.cibseven.bpm.cibseven-engine"/>
       <module name="org.cibseven.bpm.dmn.cibseven-engine-dmn"/>
+      <!-- ai-agent connector module: optional so the WAR still deploys when the
+           module is absent (AI disabled). Gives the modeler visibility to the
+           connector's bundled /element-templates/*.json (CIB7-1445). -->
+      <module name="org.cibseven.connect.cibseven-connect-ai-agent" optional="true"/>
       <system>
         <paths>
           <path name="jdk/net"/>


### PR DESCRIPTION
## What & why

Companion to the cibseven WildFly PR (CIB7-1445), which ships the ai-agent connector as a JBoss module. Wire the WildFly-deployed webclient modeler to discover its bundled element-templates.

## Changes (web + web-sb4)
- **application-wildfly.yaml**: set `cibseven.webclient.modeler.templates.paths` = `classpath*:element-templates/*.json` (bundled connector templates) + `file:${jboss.server.config.dir}/element-templates/*.json` (operator drop-in).
- **jboss-deployment-structure.xml**: add an **optional** dependency on `org.cibseven.connect.cibseven-connect-ai-agent` so the WAR can see the module's `/element-templates/*.json`. Optional ⇒ the WAR still deploys when AI is disabled/absent.

## ⚠️ Needs runtime validation (draft)
`classpath*:` directory-wildcard discovery across JBoss module boundaries is sometimes unreliable — needs a real WildFly boot to confirm the ai-agent template shows in the modeler. The `file:` drop-in is the robust fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)