### PR TITLE
fix(deps): resolve dependency CVEs in Tomcat, pgjdbc, swagger-ui (CIB7-1456)

### DIFF
--- a/cibseven-webclient-web-sb4/pom.xml
+++ b/cibseven-webclient-web-sb4/pom.xml
@@ -10,27 +10,38 @@
 	<name>CIB seven webclient web (Spring Boot 4)</name>
 	<description>Web application module for the CIB seven webclient platform (Spring Boot 4.x).</description>
 
-	<properties>
-		<!-- Override the parent's default Spring Boot version for this flavour. -->
-		<version.spring.boot>4.0.6</version.spring.boot>
-		<version.openapi-starter-webmvc-ui>3.0.2</version.openapi-starter-webmvc-ui>
-		<!--
-			Jackson 2 is no longer bundled in SB4 by default but the shared core
-			compiles against com.fasterxml.jackson.* — we pull it back in
-			explicitly. Version aligned with the transitive 2.x that swagger /
-			jjwt-jackson / springdoc bring in.
-		-->
-		<version.jackson2>2.21.2</version.jackson2>
-	</properties>
+	<!-- All version numbers live in the parent pom's <properties>; this flavour selects the
+	     SB4 variants (version.spring.boot4, version.openapi-starter-webmvc-ui4, version.tomcat). -->
 
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>${version.spring.boot}</version>
+				<version>${version.spring.boot4}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<!--
+				Apache Tomcat 11.x line for Spring Boot 4. The SB4 BOM pins 11.0.21, which is
+				affected by the same CVEs as 10.1.54 (fixed in 11.0.22). These entries override the
+				parent's SB3 tomcat-embed management (10.1.55) for this module — see CVE-2026-41293,
+				-43512, -43515, -41284, -43513, -42498, -43514.
+			-->
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-core</artifactId>
+				<version>${version.tomcat}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-el</artifactId>
+				<version>${version.tomcat}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-websocket</artifactId>
+				<version>${version.tomcat}</version>
 			</dependency>
 			<!--
 				Force convergence between the version brought by common-auth
@@ -100,7 +111,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>${version.openapi-starter-webmvc-ui}</version>
+			<version>${version.openapi-starter-webmvc-ui4}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.commons</groupId>
@@ -277,7 +288,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>${version.spring.boot}</version>
+				<version>${version.spring.boot4}</version>
 				<configuration>
 					<fork>true</fork>
 					<mainClass>org.cibseven.webapp.SevenWebclientApplication</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,38 @@
 		<jjwt.version>0.12.6</jjwt.version>
 		<commons-io.version>2.18.0</commons-io.version>
 		<common-auth.version>1.3.0</common-auth.version>
+		<!-- ============================================================================
+		     Spring Boot 3 — default flavour (cibseven-webclient-web, -core, direct-provider).
+		     ============================================================================ -->
 		<version.spring.boot>3.5.14</version.spring.boot>
 		<version.openapi-starter-webmvc-ui>2.8.13</version.openapi-starter-webmvc-ui>
+
+		<!-- ============================================================================
+		     Spring Boot 4 flavour (cibseven-webclient-web-sb4). The "4" / SB4-specific
+		     suffix marks versions that diverge from the SB3 default above. Naming mirrors
+		     cibseven-parent (~/cibseven/cibseven/parent/pom.xml) so these can be consolidated
+		     there later: version.spring-boot4, version.tomcat (11.x) vs version.tomcat10.
+		     ============================================================================ -->
+		<version.spring.boot4>4.0.6</version.spring.boot4>
+		<version.openapi-starter-webmvc-ui4>3.0.2</version.openapi-starter-webmvc-ui4>
+		<!-- SB4 no longer bundles Jackson 2, but the shared core compiles against
+		     com.fasterxml.jackson.* (Jackson 2); the SB4 module pulls it back in explicitly. -->
+		<version.jackson2>2.21.2</version.jackson2>
+
+		<!-- ============================================================================
+		     CVE overrides. This project imports spring-boot-dependencies as a BOM (not as the
+		     parent), so the usual ${tomcat.version}/${postgresql.version} BOM-property overrides
+		     do NOT take effect — the fixed versions are pinned via explicit dependencyManagement
+		     entries below.
+		     ============================================================================ -->
+		<!-- Apache Tomcat: CVE-2026-41293, -43512, -43515, -41284, -43513, -42498, -43514.
+		     SB3 runs the Tomcat 10.1.x line (fixed in 10.1.55), SB4 the 11.0.x line (fixed in 11.0.22).
+		     Suffix mirrors cibseven-parent: version.tomcat = 11.x (SB4), version.tomcat10 = 10.x (SB3). -->
+		<version.tomcat10>10.1.55</version.tomcat10>
+		<version.tomcat>11.0.22</version.tomcat>
+		<!-- swagger-ui webjar (via springdoc, both flavours): bundles DOMPurify 3.4.0 ->
+		     CVE-2026-41240, -0540, CVE-2025-15599, CVE-2026-41238, -41239 and related GHSAs. -->
+		<version.swagger-ui>5.32.6</version.swagger-ui>
 		<version.commons-lang3>3.18.0</version.commons-lang3>
 		
 		<image.tomcat-11-base>harbor.cib.de/dev/tomcat-11-base:0.1.0@sha256:49e9bd250b4bc4e33465195106831b1afa69d38c0147f9960075cb1b45a8f7f5</image.tomcat-11-base>
@@ -50,7 +80,7 @@
 		<version.log4j2>2.25.4</version.log4j2>
 
 		<!-- Database driver versions (used by modeler JPA integration) -->
-		<version.postgresql>42.7.9</version.postgresql>
+		<version.postgresql>42.7.11</version.postgresql>
 		<version.mariadb>3.5.7</version.mariadb>
 		<version.h2>2.4.240</version.h2>
 		<version.mysql>9.5.0</version.mysql>
@@ -331,6 +361,41 @@ You may obtain a copy of the License at
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-to-slf4j</artifactId>
 				<version>${version.log4j2}</version>
+			</dependency>
+
+			<!-- Override Apache Tomcat for the SB3 flavour (BOM pins the vulnerable 10.1.54) to fix
+			     CVE-2026-41293, -43512, -43515, -41284, -43513, -42498, -43514 (fixed in 10.1.55).
+			     The SB4 module overrides these to ${version.tomcat} (11.0.22) in its own pom. -->
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-core</artifactId>
+				<version>${version.tomcat10}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-el</artifactId>
+				<version>${version.tomcat10}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.tomcat.embed</groupId>
+				<artifactId>tomcat-embed-websocket</artifactId>
+				<version>${version.tomcat10}</version>
+			</dependency>
+
+			<!-- Override pgjdbc (managed by the Spring Boot BOM at 42.7.10) to fix
+			     CVE-2026-42198 (fixed in 42.7.11) -->
+			<dependency>
+				<groupId>org.postgresql</groupId>
+				<artifactId>postgresql</artifactId>
+				<version>${version.postgresql}</version>
+			</dependency>
+
+			<!-- Override the swagger-ui webjar pulled transitively by springdoc to ship
+			     DOMPurify 3.4.0 (CVE-2026-41240, -0540, CVE-2025-15599, CVE-2026-41238, -41239 + GHSAs) -->
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>swagger-ui</artifactId>
+				<version>${version.swagger-ui}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Summary

OWASP dependency-check on `cibseven-webclient-web` (2.2.0 release) flagged known CVEs in three dependencies. This pins fixed versions; a re-scan now reports **0 findings**. Fixes cover both the Spring Boot 3 (default `web`) and Spring Boot 4 (`sb4`) flavours.

Ticket: **CIB7-1456** · related to CIB7-1443 (CIB seven 2.2.0 QA).

## CVEs resolved

| Dependency | Was | Now (SB3 / SB4) | CVEs |
|---|---|---|---|
| Apache Tomcat (`tomcat-embed-core`/`-el`/`-websocket`) | 10.1.54 (SB3), 11.0.21 (SB4) | **10.1.55 / 11.0.22** | CVE-2026-41293, -43512, -43515, -41284, -43513, -42498, -43514 |
| pgjdbc (`org.postgresql:postgresql`) | 42.7.10 | **42.7.11** | CVE-2026-42198 |
| `org.webjars:swagger-ui` (bundles DOMPurify, via springdoc) | 5.28.1 (DOMPurify 3.3.x) | **5.32.6** (DOMPurify 3.4.0) | CVE-2026-41240, -0540, CVE-2025-15599, CVE-2026-41238, -41239 + GHSA-39q2-94rc-95cp, GHSA-cj63-jhhr-wcxv, GHSA-cjmm-f4jc-qw8r, GHSA-h8r8-wccr-v5f2 |

## Implementation notes

- This project imports `spring-boot-dependencies` as a **BOM** (parent is `org.cibseven:release-parent`, not `spring-boot-starter-parent`), so the usual `${tomcat.version}` / `${postgresql.version}` overrides do **not** reach the BOM — fixed versions are pinned via explicit `dependencyManagement` entries.
- The web module pulls pgjdbc transitively, so the BOM-managed version (42.7.10) wins over core's explicit declaration — the override had to be at dependencyManagement level.
- SB3 runs the Tomcat 10.1.x line, SB4 the 11.0.x line — both were vulnerable and both are patched.
- All version numbers were centralised in the root `pom.xml` `<properties>` with an SB4 differentiator mirroring `cibseven-parent` (`version.spring.boot4`, `version.tomcat` = 11.x vs `version.tomcat10` = 10.x), to ease future consolidation.

## Verification

- `mvn dependency:tree`: web → Tomcat 10.1.55 / SB 3.5.14; sb4 → Tomcat 11.0.22 / SB 4.0.6; both → postgresql 42.7.11 + swagger-ui 5.32.6.
- Re-run of OWASP dependency-check: **Total findings: 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)