### PR TITLE
fix(modeler): make ElementTemplateLoader resilient to a not-yet-created schema (CIB7-1445)

### DIFF
--- a/cibseven-webclient-core/src/main/java/org/cibseven/modeler/config/ElementTemplateProperties.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/modeler/config/ElementTemplateProperties.java
@@ -26,4 +26,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Setter
 public class ElementTemplateProperties {
     private List<String> paths;
+
+    /**
+     * Number of attempts to verify that the {@code MOD_ELEMENT_TEMPLATES} table exists
+     * before loading element templates. The table is created by the process engine
+     * (MyBatis), which has no Spring context and cannot be ordered against the webclient
+     * deployment, so on external databases (MySQL/PostgreSQL) and slow environments
+     * (e.g. arm64 under emulation) the table may not be present yet when this loader runs.
+     * Default 30 attempts.
+     */
+    private int schemaReadyMaxAttempts = 30;
+
+    /**
+     * Delay between schema-readiness attempts, in milliseconds. Default 2000ms,
+     * giving a default total wait of 60s ({@link #schemaReadyMaxAttempts} * this).
+     */
+    private long schemaReadyRetryDelayMs = 2000;
 }

--- a/cibseven-webclient-core/src/main/java/org/cibseven/modeler/util/ElementTemplateLoader.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/modeler/util/ElementTemplateLoader.java
@@ -65,13 +65,60 @@ public class ElementTemplateLoader implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		transactionTemplate.executeWithoutResult(status -> populateElementTemplatesDatabase());
+		if (properties.getPaths() == null || properties.getPaths().isEmpty()) {
+			return;
+		}
+
+		// The MOD_ELEMENT_TEMPLATES table is created by the process engine (MyBatis), which
+		// runs outside the Spring context and cannot be ordered against this deployment. Wait
+		// for it to exist before loading; if it never appears, log and skip rather than failing
+		// the whole webclient deployment.
+		if (!awaitElementTemplatesTable()) {
+			log.error("Table MOD_ELEMENT_TEMPLATES is not available after {} attempt(s); "
+					+ "skipping element template loading for this startup. The webclient will start "
+					+ "without (re)loading element templates.", properties.getSchemaReadyMaxAttempts());
+			return;
+		}
+
+		populateElementTemplatesDatabase();
+	}
+
+	/**
+	 * Polls for the existence of the {@code MOD_ELEMENT_TEMPLATES} table. Each probe runs in its
+	 * own transaction so a failed probe (table missing) is rolled back cleanly and never poisons a
+	 * subsequent attempt or the later load. Returns {@code true} once the table is queryable, or
+	 * {@code false} if it is still unavailable after the configured number of attempts.
+	 */
+	private boolean awaitElementTemplatesTable() {
+		int maxAttempts = Math.max(1, properties.getSchemaReadyMaxAttempts());
+		long delayMs = Math.max(0, properties.getSchemaReadyRetryDelayMs());
+
+		for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
+				transactionTemplate.execute(status -> elementTemplateRepository.count());
+				if (attempt > 1) {
+					log.info("Table MOD_ELEMENT_TEMPLATES became available after {} attempt(s).", attempt);
+				}
+				return true;
+			} catch (Exception e) {
+				log.info("Table MOD_ELEMENT_TEMPLATES not ready yet (attempt {}/{}): {}",
+						attempt, maxAttempts, e.getMessage());
+				if (attempt == maxAttempts) {
+					break;
+				}
+				try {
+					Thread.sleep(delayMs);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+					log.warn("Interrupted while waiting for MOD_ELEMENT_TEMPLATES table; aborting load.");
+					return false;
+				}
+			}
+		}
+		return false;
 	}
 
 	private void populateElementTemplatesDatabase() {
-		if (properties.getPaths() == null) {
-			return;
-		}
 		for (String path : properties.getPaths()) {
 			loadElementTemplatesFromPath(path);
 		}
@@ -102,12 +149,12 @@ public class ElementTemplateLoader implements InitializingBean {
 	private void loadElementTemplatesFromResource(Resource resource) {
 		String description = resource.getDescription();
 
+		List<JsonNode> templateNodes;
 		try (InputStream inputStream = resource.getInputStream()) {
 			log.info("Loading element templates from JSON at '{}'...", description);
 
 			JsonNode root = mapper.readTree(inputStream);
 
-			List<JsonNode> templateNodes;
 			if (root.isArray()) {
 				templateNodes = new ArrayList<>(root.size());
 				root.forEach(templateNodes::add);
@@ -117,40 +164,61 @@ public class ElementTemplateLoader implements InitializingBean {
 				log.error("Expected JSON object or array in '{}', but found: {}", description, root.getNodeType());
 				return;
 			}
-
-			List<ElementTemplate> newTemplates = new ArrayList<>();
-			int updated = 0;
-
-			for (JsonNode templateNode : templateNodes) {
-				try {
-					ElementTemplate jsonTemplate = mapper.treeToValue(templateNode, ElementTemplate.class);
-					jsonTemplate.setOrigin(ElementTemplateOrigin.DEFAULT_JSON);
-					jsonTemplate.setContent(mapper.writeValueAsString(templateNode));
-
-					ElementTemplate existing = elementTemplateRepository
-							.findElementTemplateById(jsonTemplate.getTemplateId());
-
-					if (existing != null) {
-						jsonTemplate.setId(existing.getId());
-						elementTemplateRepository.save(jsonTemplate);
-						updated++;
-					} else {
-						newTemplates.add(jsonTemplate);
-					}
-				} catch (Exception e) {
-					log.error("Error processing template from '{}': {}", description, e.getMessage(), e);
-				}
-			}
-
-			if (!newTemplates.isEmpty()) {
-				elementTemplateRepository.saveAll(newTemplates);
-			}
-
-			log.info("Successfully loaded {} element templates from '{}': {} updated, {} inserted",
-					templateNodes.size(), description, updated, newTemplates.size());
 		} catch (IOException ioe) {
 			log.error("Failed to read element templates JSON at '{}'", description, ioe);
+			return;
 		}
+
+		int updated = 0;
+		int inserted = 0;
+		int failed = 0;
+
+		for (JsonNode templateNode : templateNodes) {
+			// Parse outside the transaction; only the DB upsert is transactional.
+			ElementTemplate parsed;
+			try {
+				parsed = mapper.treeToValue(templateNode, ElementTemplate.class);
+				parsed.setOrigin(ElementTemplateOrigin.DEFAULT_JSON);
+				parsed.setContent(mapper.writeValueAsString(templateNode));
+			} catch (Exception e) {
+				failed++;
+				log.error("Error parsing element template from '{}': {}", description, e.getMessage(), e);
+				continue;
+			}
+
+			// Each template is upserted in its own transaction, so a failure rolls back only that
+			// template and never poisons the next one or the rest of the batch.
+			try {
+				if (Boolean.TRUE.equals(transactionTemplate.execute(status -> upsertTemplate(parsed)))) {
+					updated++;
+				} else {
+					inserted++;
+				}
+			} catch (Exception e) {
+				failed++;
+				log.error("Error saving element template '{}' from '{}': {}",
+						parsed.getTemplateId(), description, e.getMessage(), e);
+			}
+		}
+
+		log.info("Processed {} element templates from '{}': {} updated, {} inserted, {} failed",
+				templateNodes.size(), description, updated, inserted, failed);
+	}
+
+	/**
+	 * Inserts or updates a single element template. Runs inside the caller-provided transaction.
+	 *
+	 * @return {@code true} if an existing template was updated, {@code false} if a new one was inserted.
+	 */
+	private boolean upsertTemplate(ElementTemplate template) {
+		ElementTemplate existing = elementTemplateRepository.findElementTemplateById(template.getTemplateId());
+		if (existing != null) {
+			template.setId(existing.getId());
+			elementTemplateRepository.save(template);
+			return true;
+		}
+		elementTemplateRepository.save(template);
+		return false;
 	}
 
 }


### PR DESCRIPTION
## Problem

The `cibseven-docker` WildFly smoke test fails intermittently — frequently on **arm64**, occasionally on **amd64** — with the webclient war failing to deploy:

```
Table 'process-engine.MOD_ELEMENT_TEMPLATES' doesn't exist
  -> ElementTemplateLoader: Error processing template ... cibseven-ai-agent.json
  -> IJ031070: Transaction cannot proceed: STATUS_MARKED_ROLLBACK   (every later template)
  -> BeanCreationException: 'elementTemplateLoader' ... JTA transaction unexpectedly rolled back
  -> MSC000001: Failed to start ...cibseven-webclient-web...war.undertow-deployment
WildFly ... started (with errors)   -> smoke test exit 1
```

### Root cause

`MOD_ELEMENT_TEMPLATES` is created by the process engine (MyBatis), which runs **outside the Spring context** and cannot be ordered against the webclient deployment. On external DBs (MySQL/PostgreSQL) and slow environments (arm64 under emulation), the table may not exist yet when `ElementTemplateLoader` runs at startup. H2 (in-memory) always wins the race, which is why only the external-DB / slow-arch runs failed.

Two compounding bugs in `ElementTemplateLoader`:
1. **One shared transaction** wrapped *all* templates. The first "table doesn't exist" marked it rollback-only, so the per-template `try/catch` was useless — every later op hit `STATUS_MARKED_ROLLBACK` and the final commit threw `UnexpectedRollbackException`, failing the bean and the whole war.
2. **No wait** for the engine to create the table.

## Fix

- **Wait** for `MOD_ELEMENT_TEMPLATES` with bounded retries, each probe in its own transaction (configurable via `cibseven.webclient.modeler.templates.schema-ready-max-attempts` / `-retry-delay-ms`; default 30 × 2000ms = 60s).
- **Per-template transaction** for each upsert, so one failure never poisons the rest of the batch.
- **Degrade, don't crash**: if the table never appears, log and skip instead of throwing, so the webclient still deploys.

## Scope / notes

- Shared `cibseven-webclient-core` loader → applies to both the SB3 (`-web`) and SB4 (`-web-sb4`) WARs.
- No behavioural change when the table already exists (the common case) beyond a single cheap readiness probe.
- `mvn -pl cibseven-webclient-core clean compile` → BUILD SUCCESS.

Jira: CIB7-1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)