### PR TITLE
refactor(Decision): rename duplicated InstancesTable to DecisionInstancesTable

### DIFF
--- a/frontend/src/components/decision/DecisionDefinitionVersion.vue
+++ b/frontend/src/components/decision/DecisionDefinitionVersion.vue
@@ -60,7 +60,7 @@
           </div>
         </div>
         <div ref="rContent" class="overflow-auto bg-white position-absolute w-100" style="top: 60px; left: 0; bottom: 0" @scroll="handleScrollDecisions">
-          <InstancesTable ref="instancesTable" v-if="!loading && decisionInstances.length > 0 && !sorting" :instances="decisionInstances" :sortByDefaultKey="sortByDefaultKey" :sortDesc="sortDesc"></InstancesTable>
+          <DecisionInstancesTable ref="instancesTable" v-if="!loading && decisionInstances.length > 0 && !sorting" :instances="decisionInstances" :sortByDefaultKey="sortByDefaultKey" :sortDesc="sortDesc"></DecisionInstancesTable>
           <div v-else-if="loading" class="py-3 text-center w-100">
             <BWaitingBox class="d-inline me-2" styling="width: 35px"></BWaitingBox> {{ $t('admin.loading') }}
           </div>
@@ -77,7 +77,7 @@
 
 import { permissionsMixin } from '@/permissions.js'
 import DmnViewer from '@/components/decision/DmnViewer.vue'
-import InstancesTable from '@/components/decision/InstancesTable.vue'
+import DecisionInstancesTable from '@/components/decision/DecisionInstancesTable.vue'
 import resizerMixin from '@/components/process/mixins/resizerMixin.js'
 import ScrollableTabsContainer from '@/components/common-components/ScrollableTabsContainer.vue'
 import ViewerFrame from '@/components/common-components/ViewerFrame.vue'
@@ -87,7 +87,7 @@ import { debounce } from '@/utils/debounce.js'
 
 export default {
   name: 'DecisionDefinitionVersion',
-  components: { DmnViewer, InstancesTable, ViewerFrame, BWaitingBox, GenericTabs, ScrollableTabsContainer },
+  components: { DmnViewer, DecisionInstancesTable, ViewerFrame, BWaitingBox, GenericTabs, ScrollableTabsContainer },
   mixins: [permissionsMixin, resizerMixin],
   props: {
     versionIndex: String,

--- a/frontend/src/components/decision/DecisionInstancesTable.vue
+++ b/frontend/src/components/decision/DecisionInstancesTable.vue
@@ -79,7 +79,7 @@ import { FlowTable, SuccessAlert, CopyableActionButton } from '@cib/common-front
 import { mapMutations, mapGetters } from 'vuex'
 
 export default {
-  name: 'InstancesTable',
+  name: 'DecisionInstancesTable',
   components: { FlowTable, SuccessAlert, CopyableActionButton },
   mixins: [copyToClipboardMixin, permissionsMixin],
   props: {

--- a/frontend/src/library.js
+++ b/frontend/src/library.js
@@ -138,6 +138,7 @@ export { default as DecisionList } from '@/components/decisions/list/DecisionLis
 export { default as DecisionListView } from '@/components/decisions/list/DecisionListView.vue'
 export { default as DecisionInstance } from './components/decision/DecisionInstance.vue'
 export { default as DecisionDefinitionVersion } from '@/components/decision/DecisionDefinitionVersion.vue'
+export { default as DecisionInstancesTable } from '@/components/decision/DecisionInstancesTable.vue'
 export { default as TenantsView } from '@/components/tenants/TenantsView.vue'
 export { default as EditTenant } from './components/tenants/EditTenant.vue'
 export { default as CreateTenant } from './components/tenants/CreateTenant.vue'


### PR DESCRIPTION
InstancesTable.vue exists in frontend\src\components\decision as well as in frontend\src\components\process\tables
for clarity-purposes, the file in decision is renamed to DecisionInstancesTable.vue

CIB7-1550