### PR TITLE
chore(wildfly): simplify to avoid tomcat-embed exclusion warning

### DIFF
--- a/cibseven-webclient-web-sb4/assembly-war-wildfly.xml
+++ b/cibseven-webclient-web-sb4/assembly-war-wildfly.xml
@@ -49,6 +49,7 @@
             <unpack>false</unpack>
             <excludes>
                 <exclude>org.apache.tomcat.embed:*</exclude>
+                <exclude>org.jboss.logging:jboss-logging</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/cibseven-webclient-web-sb4/assembly-war-wildfly.xml
+++ b/cibseven-webclient-web-sb4/assembly-war-wildfly.xml
@@ -48,10 +48,7 @@
             <useProjectArtifact>true</useProjectArtifact>
             <unpack>false</unpack>
             <excludes>
-                <exclude>org.apache.tomcat.embed:tomcat-embed-el</exclude>
-                <exclude>org.apache.tomcat.embed:tomcat-embed-core</exclude>
-                <exclude>org.apache.tomcat.embed:tomcat-embed-websocket</exclude>
-                <exclude>org.jboss.logging:jboss-logging</exclude>
+                <exclude>org.apache.tomcat.embed:*</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/cibseven-webclient-web/assembly-war-wildfly.xml
+++ b/cibseven-webclient-web/assembly-war-wildfly.xml
@@ -48,9 +48,7 @@
             <useProjectArtifact>true</useProjectArtifact>
             <unpack>false</unpack>
             <excludes>
-                <exclude>org.apache.tomcat.embed:tomcat-embed-el</exclude>
-                <exclude>org.apache.tomcat.embed:tomcat-embed-core</exclude>
-                <exclude>org.apache.tomcat.embed:tomcat-embed-websocket</exclude>
+                <exclude>org.apache.tomcat.embed:*</exclude>
                 <exclude>org.jboss.logging:jboss-logging</exclude>
             </excludes>
         </dependencySet>


### PR DESCRIPTION
No tomcat-embed lib is needed for wildfly package:
https://mvnrepository.com/search?q=org.apache.tomcat.embed