### PR TITLE
fix(rest): [CIB7] correct resource/permission pairs in checkPermission

### DIFF
--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/HistoryProcessService.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/HistoryProcessService.java
@@ -124,7 +124,7 @@ public class HistoryProcessService extends BaseService {
 			@Parameter(description = "Variable values ignore case") @RequestParam Optional<Boolean> variableValuesIgnoreCase,
 			@Parameter(description = "Deserialize values") @RequestParam Optional<Boolean> deserializeValues,
 			Locale loc, CIBUser user) {
-		checkPermission(user, SevenResourceType.PROCESS_DEFINITION, PermissionConstants.READ_INSTANCE_VARIABLE_ALL);
+		checkPermission(user, SevenResourceType.PROCESS_DEFINITION, PermissionConstants.READ_HISTORY_ALL);
 		final Map<String, Object> data = new HashMap<>();
 		data.put("variableName", variableName.orElse(null));
 		data.put("variableNameLike", variableNameLike.orElse(null));
@@ -153,7 +153,7 @@ public class HistoryProcessService extends BaseService {
 			@Parameter(description = "Process instance Id") @PathVariable String id,
 			Locale loc, HttpServletRequest rq) {
 		CIBUser user = checkAuthorization(rq, true);
-		checkPermission(user, SevenResourceType.HISTORIC_PROCESS_INSTANCE, PermissionConstants.DELETE_ALL);
+		checkPermission(user, SevenResourceType.PROCESS_DEFINITION, PermissionConstants.DELETE_HISTORY_ALL);
 		bpmProvider.deleteProcessInstanceFromHistory(id, user);
     // return 204 No Content, no body
     return ResponseEntity.noContent().build();
@@ -165,7 +165,7 @@ public class HistoryProcessService extends BaseService {
 	public ResponseEntity<Void> deleteVariableHistoryInstance(
 			@Parameter(description = "Id of the variable") @PathVariable String id,
 			Locale loc, CIBUser user) {
-		checkPermission(user, SevenResourceType.HISTORIC_PROCESS_INSTANCE, PermissionConstants.DELETE_ALL);
+		checkPermission(user, SevenResourceType.PROCESS_DEFINITION, PermissionConstants.DELETE_HISTORY_ALL);
 		bpmProvider.deleteVariableHistoryInstance(id, user);
     // return 204 No Content, no body
     return ResponseEntity.noContent().build();

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/HistoryTaskService.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/HistoryTaskService.java
@@ -61,7 +61,7 @@ public class HistoryTaskService extends BaseService {
 			@Parameter(description = "Restrict to tasks that have the given key") @RequestParam String taskDefinitionKey,
 			@Parameter(description = "Process instance Id") @RequestParam String processInstanceId,
 			Locale loc, CIBUser user) {
-		checkPermission(user, SevenResourceType.TASK, PermissionConstants.READ_ALL);
+		checkPermission(user, SevenResourceType.HISTORIC_TASK, PermissionConstants.READ_ALL);
 		return bpmProvider.findTasksByDefinitionKeyHistory(taskDefinitionKey, processInstanceId, user);
 	}
 
@@ -74,7 +74,7 @@ public class HistoryTaskService extends BaseService {
 	public Collection<TaskHistory> findTasksByProcessInstanceHistory(
 			@Parameter(description = "Process instance Id") @PathVariable String processInstanceId,
 			Locale loc, CIBUser user) {
-		checkPermission(user, SevenResourceType.TASK, PermissionConstants.READ_ALL);
+		checkPermission(user, SevenResourceType.HISTORIC_TASK, PermissionConstants.READ_ALL);
 		return bpmProvider.findTasksByProcessInstanceHistory(processInstanceId, user);
 	}
 	
@@ -87,7 +87,7 @@ public class HistoryTaskService extends BaseService {
 	public Collection<TaskHistory> findTasksByTaskIdHistory(
 			@Parameter(description = "Task Id") @PathVariable String taskId,
 			Locale loc, CIBUser user) {
-		checkPermission(user, SevenResourceType.TASK, PermissionConstants.READ_ALL);
+		checkPermission(user, SevenResourceType.HISTORIC_TASK, PermissionConstants.READ_ALL);
 		return bpmProvider.findTasksByTaskIdHistory(taskId, user);
 	}
 	

--- a/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/ProcessService.java
+++ b/cibseven-webclient-core/src/main/java/org/cibseven/webapp/rest/ProcessService.java
@@ -952,7 +952,7 @@ public class ProcessService extends BaseService implements InitializingBean {
 	public ResponseEntity<Variable> fetchVariableByProcessInstanceId(@PathVariable String processInstanceId, @PathVariable String variableName, HttpServletRequest rq) {
 		try {
 			CIBUser userAuth = (CIBUser) baseUserProvider.authenticateUser(rq);
-			checkPermission(userAuth, SevenResourceType.PROCESS_DEFINITION, PermissionConstants.UPDATE_INSTANCE_VARIABLE_ALL);
+			checkPermission(userAuth, SevenResourceType.PROCESS_DEFINITION, PermissionConstants.READ_INSTANCE_VARIABLE_ALL);
 			Variable variable = bpmProvider.fetchVariableByProcessInstanceId(processInstanceId, variableName, userAuth);    
 			return ResponseEntity.ok(variable);
 		} catch (Exception e) {


### PR DESCRIPTION
Audited all 161 checkPermission calls across the 18 REST services against the engine's resource/permission matrix, validating every pair used in the code against a live engine via isUserAuthorized. Seven calls were wrong.

Invalid pair, rejected by the engine (HistoryProcessService, DELETE /process-history/instance/{id} and .../variables): HISTORIC_PROCESS_INSTANCE supports only READ, so the DELETE check could only ever be satisfied by a blanket ALL grant. The engine reports "The permission 'DELETE' is not valid for 'HISTORIC_PROCESS_INSTANCE' resource type." Deleting historic data is authorized by DELETE_HISTORY on PROCESS_DEFINITION.

Read demanding a write permission (ProcessService, GET {processInstanceId}/variable/{variableName}): checked UPDATE_INSTANCE_VARIABLE, copy-pasted from saveVariable directly above it. The other variable-read endpoints in the same file already use READ_INSTANCE_VARIABLE.

History endpoints checking runtime resources: the three /task-history/* endpoints checked TASK instead of HISTORIC_TASK, while EmbeddedFormHistoryService already used HISTORIC_TASK for the same operation; and historic variable reads checked the runtime READ_INSTANCE_VARIABLE instead of READ_HISTORY.

Note this last group is a behaviour change: a user holding read rights on live tasks or variables but no history permission is now refused on those four endpoints. That is the intended model, but it affects deployments running with cibseven.webclient.deprecated.authorization.enabled=true.

These fixes make the checks correct, not sufficient. SevenAuthorizationUtils.checkPermission still ignores resourceId and cannot protect an individual object; per-instance enforcement remains the engine's job.

Not verified by a local build: compilation fails in this workspace for unrelated reasons (Lombok-generated accessors unresolved in cibseven-interfaces), identically on a clean tree. The changes are constant and enum-member substitutions with unchanged method signatures and existing imports. CI must confirm.